### PR TITLE
lots of new features, bug fixes, and colab-based tests

### DIFF
--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -1,10 +1,10 @@
-from pkg_resources import get_distribution
+import pkg_resources
 
 from davos._davos import Davos
 
 
 __all__ = ['davos', 'smuggle', 'activate', 'deactivate', 'is_active']
-__version__ = get_distribution('davos').version
+__version__ = pkg_resources.get_distribution('davos').version
 
 
 davos = Davos()

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -21,3 +21,5 @@ smuggle = davos.smuggler
 #  parsed by smuggle parser
 # TODO: conditionally add arguments to parsers based on user's installed
 #  version of installer
+# TODO: integrate sensible installer flags into davos behavior (e.g.,
+#  logging, verbosity, etc.)

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -9,3 +9,15 @@ __version__ = get_distribution('davos').version
 davos = Davos()
 davos.initialize()
 smuggle = davos.smuggler
+
+
+# FIXME: find NotImplementedErrors raised during parsing step and change
+#  to ParserNotImplementedErrors
+# TODO: add tree diagram to davos.exceptions module to show class
+#  hierarchy
+# TODO: Come up with way to supply proper filename, lineno, columnno,
+#  etc. to SyntaxErrors and subclasses
+# TODO: provide a way to indicate that imported modules should ALSO be
+#  parsed by smuggle parser
+# TODO: conditionally add arguments to parsers based on user's installed
+#  version of installer

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -3,12 +3,16 @@ from pkg_resources import get_distribution
 from davos._davos import Davos
 
 
-__all__ = ['davos', 'smuggle']
+__all__ = ['davos', 'smuggle', 'activate', 'deactivate']
 __version__ = get_distribution('davos').version
+
 
 davos = Davos()
 davos.initialize()
+
 smuggle = davos.smuggler
+activate = davos.activate_parser
+deactivate = davos.deactivate_parser
 
 
 # TODO: add tree diagram to davos.exceptions module to show class

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -11,8 +11,6 @@ davos.initialize()
 smuggle = davos.smuggler
 
 
-# FIXME: find NotImplementedErrors raised during parsing step and change
-#  to ParserNotImplementedErrors
 # TODO: add tree diagram to davos.exceptions module to show class
 #  hierarchy
 # TODO: Come up with way to supply proper filename, lineno, columnno,

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -3,7 +3,7 @@ from pkg_resources import get_distribution
 from davos._davos import Davos
 
 
-__all__ = ['davos', 'smuggle', 'activate', 'deactivate']
+__all__ = ['davos', 'smuggle', 'activate', 'deactivate', 'is_active']
 __version__ = get_distribution('davos').version
 
 
@@ -13,6 +13,7 @@ davos.initialize()
 smuggle = davos.smuggler
 activate = davos.activate_parser
 deactivate = davos.deactivate_parser
+is_active = davos.parser_is_active
 
 
 # TODO: add tree diagram to davos.exceptions module to show class

--- a/davos/__init__.py
+++ b/davos/__init__.py
@@ -14,15 +14,3 @@ smuggle = davos.smuggler
 activate = davos.activate_parser
 deactivate = davos.deactivate_parser
 is_active = davos.parser_is_active
-
-
-# TODO: add tree diagram to davos.exceptions module to show class
-#  hierarchy
-# TODO: Come up with way to supply proper filename, lineno, columnno,
-#  etc. to SyntaxErrors and subclasses
-# TODO: provide a way to indicate that imported modules should ALSO be
-#  parsed by smuggle parser
-# TODO: conditionally add arguments to parsers based on user's installed
-#  version of installer
-# TODO: integrate sensible installer flags into davos behavior (e.g.,
-#  logging, verbosity, etc.)

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -9,7 +9,6 @@ __all__ = ['Davos', 'capture_stdout']
 
 
 import sys
-from functools import partial
 from contextlib import redirect_stdout
 from io import StringIO
 from subprocess import CalledProcessError
@@ -120,21 +119,16 @@ class capture_stdout:
     def __init__(self, *streams, closing=True):
         self.streams = streams
         self.closing = closing
-        try:
-            sys_ = globals()['sys']
-        except KeyError:
-            import sys as sys_
-        self.sys_ = sys_
-        self.sys_stdout_write = sys_.stdout.write
+        self.sys_stdout_write = sys.stdout.write
 
     def __enter__(self):
-        self.sys_.stdout.write = self._write
+        sys.stdout.write = self._write
         if len(self.streams) == 1:
             return self.streams[0]
         return self.streams
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.sys_.stdout.write = self.sys_stdout_write
+        sys.stdout.write = self.sys_stdout_write
         if self.closing:
             for s in self.streams:
                 s.close()
@@ -143,4 +137,4 @@ class capture_stdout:
         for s in self.streams:
             s.write(data)
         self.sys_stdout_write(data)
-        self.sys_.stdout.flush()
+        sys.stdout.flush()

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -16,6 +16,7 @@ from subprocess import CalledProcessError
 
 # noinspection PyAttributeOutsideInit
 class Davos:
+    # ADD DOCSTRING
     __instance = None
 
     def __new__(cls):

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -40,6 +40,8 @@ class Davos:
             # running with vanilla Python interpreter
             import davos.python as internals
             self.smuggler = internals.smuggle_python
+            self.activate_parser = internals.activate_parser_python
+            self.deactivate_parser = internals.deactivate_parser_python
             self._shell_cmd_helper = internals.run_shell_command_python
             self.ipython_shell = None
             self.parser_environment = 'PY'
@@ -50,6 +52,8 @@ class Davos:
                 # Notebook version
                 import davos.colab as internals
                 self.smuggler = internals.smuggle_colab
+                self.activate_parser = internals.activate_parser_colab
+                self.deactivate_parser = internals.deactivate_parser_colab
                 self._shell_cmd_helper = internals.run_shell_command_colab
                 self.parser_environment = 'IPY_OLD'
             else:
@@ -57,9 +61,11 @@ class Davos:
                 # version
                 import davos.jupyter as internals
                 self.smuggler = internals.smuggle_jupyter
+                self.activate_parser = internals.activate_parser_jupyter
+                self.deactivate_parser = internals.deactivate_parser_jupyter
                 self._shell_cmd_helper = internals.run_shell_command_jupyter
                 self.parser_environment = 'IPY_NEW'
-        self.smuggler._register()
+        self.activate_parser()
 
     def run_shell_command(self, command, live_stdout=None):
         if live_stdout is None:

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -42,6 +42,7 @@ class Davos:
             self.smuggler = internals.smuggle_python
             self.activate_parser = internals.activate_parser_python
             self.deactivate_parser = internals.deactivate_parser_python
+            self.parser_is_active = internals.check_parser_active_python
             self._shell_cmd_helper = internals.run_shell_command_python
             self.ipython_shell = None
             self.parser_environment = 'PY'
@@ -54,6 +55,7 @@ class Davos:
                 self.smuggler = internals.smuggle_colab
                 self.activate_parser = internals.activate_parser_colab
                 self.deactivate_parser = internals.deactivate_parser_colab
+                self.parser_is_active = internals.check_parser_active_colab
                 self._shell_cmd_helper = internals.run_shell_command_colab
                 self.parser_environment = 'IPY_OLD'
             else:
@@ -63,6 +65,7 @@ class Davos:
                 self.smuggler = internals.smuggle_jupyter
                 self.activate_parser = internals.activate_parser_jupyter
                 self.deactivate_parser = internals.deactivate_parser_jupyter
+                self.parser_is_active = internals.check_parser_active_jupyter
                 self._shell_cmd_helper = internals.run_shell_command_jupyter
                 self.parser_environment = 'IPY_NEW'
         self.activate_parser()

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -83,6 +83,12 @@ class Davos:
 
 
 class capture_stdout:
+    # TODO: move me to davos.core?
+    """
+    Context manager similar to `contextlib.redirect_stdout`, but
+    temporarily writes stdout to another stream *in addition to* --
+    rather than *instead of* -- `sys.stdout`
+    """
     def __init__(self, stream):
         self.stream = stream
         self.sys_stdout_write = sys.stdout.write

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -118,8 +118,8 @@ class capture_stdout:
             sys_ = globals()['sys']
         except KeyError:
             import sys as sys_
-        self.sys_ = sys
-        self.sys_stdout_write = sys.stdout.write
+        self.sys_ = sys_
+        self.sys_stdout_write = sys_.stdout.write
 
     def __enter__(self):
         self.sys_.stdout.write = self._write

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -59,6 +59,10 @@ class Davos:
                 self.parser_is_active = internals.check_parser_active_colab
                 self._shell_cmd_helper = internals.run_shell_command_colab
                 self.parser_environment = 'IPY_OLD'
+                # store InteractiveShell's original showsyntaxerror
+                # method so it can be referenced from our overridden
+                # version
+                self._ipython_showsyntaxerror_orig = self.ipython_shell._showsyntaxerror
             else:
                 # running in a new(-ish) IPython/Jupyter Notebook
                 # version

--- a/davos/_davos.py
+++ b/davos/_davos.py
@@ -61,7 +61,7 @@ class Davos:
                 # store InteractiveShell's original showsyntaxerror
                 # method so it can be referenced from our overridden
                 # version
-                self._ipython_showsyntaxerror_orig = self.ipython_shell._showsyntaxerror
+                self._ipython_showsyntaxerror_orig = self.ipython_shell.showsyntaxerror
             else:
                 # running in a new(-ish) IPython/Jupyter Notebook
                 # version

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -11,6 +11,7 @@ versions of IPython will also use this approach
 
 __all__ = [
     'activate_parser_colab',
+    'check_parser_active_colab',
     'deactivate_parser_colab',
     'run_shell_command_colab',
     'smuggle_colab',
@@ -78,6 +79,20 @@ def activate_parser_colab():
         manager_xforms.append(smuggle_transformer())
 
     colab_shell.user_ns['smuggle'] = smuggle_colab
+
+
+def check_parser_active_colab():
+    # ADD DOCSTRING
+    colab_shell = davos.ipython_shell
+    # noinspection PyDeprecation
+    splitter_xforms = colab_shell.input_splitter.python_line_transforms
+    manager_xforms = colab_shell.input_transformer_manager.python_line_transforms
+    if (
+            any(t.func is smuggle_parser_colab for t in splitter_xforms) and
+            any(t.func is smuggle_parser_colab for t in manager_xforms)
+    ):
+        return True
+    return False
 
 
 # noinspection PyDeprecation

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -196,8 +196,8 @@ def smuggle_parser_colab(line):
         is_from_statement = True
         onion_chars = matched_groups['FROM_ONION'] or matched_groups['FROM_ONION_1']
         has_semicolon_sep = matched_groups['FROM_SEMICOLON_SEP'] is not None
-        pkg_name = cmd_prefix.split()[1] + '.'
-        to_smuggle = re.sub(r'[()]|\s*\#.*$\s*', ' ', to_smuggle, flags=re.MULTILINE)
+        qualname_prefix = cmd_prefix.split()[1] + '.'
+        to_smuggle = re.sub(r'[()]|\s*\#.*$\s*', ' ', to_smuggle, flags=re.M)
         to_smuggle = to_smuggle.rstrip(', ')
     else:
         # cmd_prefix == ''
@@ -221,16 +221,20 @@ def smuggle_parser_colab(line):
     for na in names_aliases:
         if ' as ' in na:
             name, alias = na.split(' as ')
-            name = '"' + name.strip() + '"'
             alias = '"' + alias.strip() + '"'
+            if is_from_statement:
+                name = '"' + qualname_prefix + name.strip() + '"'
+            else:
+                name = '"' + name.strip() + '"'
         else:
             na = na.strip()
             if is_from_statement:
-                name = '"' + cmd_prefix.split()[1] + '.' + na + '"'
+                name = '"' + qualname_prefix + na + '"'
                 alias = '"' + na + '"'
             else:
                 name = '"' + na + '"'
                 alias = None
+
         smuggle_funcs.append(f'smuggle(name={name}, as_={alias})')
 
     smuggle_funcs[0] = smuggle_funcs[0][:-1] + kwargs_str + ')'

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -53,6 +53,7 @@ NO_RELOAD_MODULES = (
     'numpy._globals',
     'davos',
     'importlib',
+    'types',
     *sys.builtin_module_names
 )
 
@@ -190,6 +191,10 @@ def smuggle_colab(
 
     if install_pkg:
         installer_stdout, exit_code = onion.install_package()
+        # remove package and all of its subpackages from sys.modules
+        for name in tuple(sys.modules.keys()):
+            if name.startswith(f'{pkg_name}.') or name == pkg_name:
+                del sys.modules[name]
         # invalidate sys.meta_path module finder caches. Forces import
         # machinery to notice newly installed module
         importlib.invalidate_caches()

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -332,7 +332,9 @@ def smuggle_parser_colab(line):
     else:
         # cmd_prefix == ''
         is_from_statement = False
-        onion_chars = matched_groups['ONION'].replace('"', "'")
+        onion_chars = matched_groups['ONION']
+        if onion_chars is not None:
+            onion_chars = onion_chars.replace('"', "'")
         has_semicolon_sep = matched_groups['SEMICOLON_SEP'] is not None
         qualname_prefix = ''
 

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -227,12 +227,16 @@ def smuggle_parser_colab(line):
     for na in names_aliases:
         if ' as ' in na:
             name, alias = na.split(' as ')
-            name, alias = name.strip(), alias.strip()
-        elif is_from_statement:
-            alias = na.strip()
-            name = cmd_prefix.split()[1] + '.' + alias
+            name = '"' + name.strip() + '"'
+            alias = '"' + alias.strip() + '"'
         else:
-            name, alias = na.strip(), None
+            na = na.strip()
+            if is_from_statement:
+                name = '"' + cmd_prefix.split()[1] + '.' + na + '"'
+                alias = '"' + na + '"'
+            else:
+                name = '"' + na + '"'
+                alias = None
         smuggle_funcs.append(f'smuggle(name={name}, as_={alias})')
     smuggle_funcs[0] = smuggle_funcs[0][:-1] + kwargs_str + ')'
     return before_chars + '; '.join(smuggle_funcs) + after_chars

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -22,7 +22,6 @@ __all__ = [
 import importlib
 import re
 import sys
-import warnings
 from subprocess import CalledProcessError
 
 from davos import davos
@@ -42,20 +41,6 @@ if davos.ipython_shell is not None:
         from google.colab._pip import (
             _previously_imported_packages as get_updated_imported_pkgs
         )
-
-
-NO_RELOAD_MODULES = (
-    'sys',
-    'os.path',
-    'builtins',
-    '__main__',
-    'numpy',
-    'numpy._globals',
-    'davos',
-    'importlib',
-    'types',
-    *sys.builtin_module_names
-)
 
 
 def _showsyntaxerror_davos(colab_shell, filename=None):

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -181,7 +181,7 @@ def smuggle_colab(
             davos.ipython_shell.user_ns[name] = imported_obj
     else:
         davos.ipython_shell.user_ns[as_] = imported_obj
-    davos.smuggled[onion.install_name] = onion.version_spec
+    davos.smuggled[onion.import_name] = onion.args_str
 
 
 def smuggle_parser_colab(line):

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -51,7 +51,9 @@ NO_RELOAD_MODULES = (
     '__main__',
     'numpy',
     'numpy._globals',
-    'davos'
+    'davos',
+    'importlib',
+    *sys.builtin_module_names
 )
 
 

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -224,7 +224,7 @@ def smuggle_parser_colab(line):
 
     smuggle_funcs = []
     names_aliases = to_smuggle.split(',')
-    for na in names_aliases[1:]:
+    for na in names_aliases:
         if ' as ' in names_aliases:
             name, alias = na.split(' as ')
             name, alias = name.strip(), alias.strip()

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -332,7 +332,7 @@ def smuggle_parser_colab(line):
     else:
         # cmd_prefix == ''
         is_from_statement = False
-        onion_chars = matched_groups['ONION']
+        onion_chars = matched_groups['ONION'].replace('"', "'")
         has_semicolon_sep = matched_groups['SEMICOLON_SEP'] is not None
         qualname_prefix = ''
 

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -44,8 +44,13 @@ if davos.ipython_shell is not None:
 
 def activate_parser_colab():
     """
+    **Available in public API via `davos.activate()`**
+
     Registers the `davos` parser as an IPython `InputTransformer` that
-    will be called on the contents of each code cell.
+    will be called on the contents of each code cell.  Can be run
+    manually (`davos.activate()`) after deactivating parser
+    (`davos.deactivate()`) to re-enable the `davos` parser for all
+    future cells (**including the current cell**).
 
     Notes
     -----
@@ -78,11 +83,23 @@ def activate_parser_colab():
 # noinspection PyDeprecation
 def deactivate_parser_colab():
     """
-    Stops the `davos` parser from running for all future cells
-    (including the current cell) until reactivated.
+    **Available in public API via `davos.deactivate()`**
+
+    Disables the `davos` parser for all future cells (**including the
+    current cell**).  The parser may be re-enabled by calling
+    `davos.activate()`.
 
     Notes
     -----
+    1. Any `smuggle` statements following a call to `davos.deactivate()`
+       will result in `SyntaxError`s unless the parser is reactivated
+       first.
+    2. The `davos` parser adds very minimal overhead to cell execution.
+       However, running `davos.deactivate()` once the parser is no
+       longer needed (i.e., after the last `smuggle` statement) may be
+       useful when measuring precise runtimes (e.g. profiling code),
+       particularly because the overhead added is a function of the
+       number of lines rather than complexity.
     *See notes for `activate_parser_colab()`*
     """
     colab_shell = davos.ipython_shell

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -225,7 +225,7 @@ def smuggle_parser_colab(line):
     smuggle_funcs = []
     names_aliases = to_smuggle.split(',')
     for na in names_aliases:
-        if ' as ' in names_aliases:
+        if ' as ' in na:
             name, alias = na.split(' as ')
             name, alias = name.strip(), alias.strip()
         elif is_from_statement:

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -221,18 +221,18 @@ def smuggle_parser_colab(line):
     for na in names_aliases:
         if ' as ' in na:
             name, alias = na.split(' as ')
-            alias = '"' + alias.strip() + '"'
+            alias = f'"{alias.strip()}"'
             if is_from_statement:
-                name = '"' + qualname_prefix + name.strip() + '"'
+                name = f'"{qualname_prefix}{name.strip()}"'
             else:
-                name = '"' + name.strip() + '"'
+                name = f'"{name.strip()}"'
         else:
             na = na.strip()
             if is_from_statement:
-                name = '"' + qualname_prefix + na + '"'
-                alias = '"' + na + '"'
+                name = f'"{qualname_prefix}{na}"'
+                alias = f'"{na}"'
             else:
-                name = '"' + na + '"'
+                name = f'"{na}"'
                 alias = None
 
         smuggle_funcs.append(f'smuggle(name={name}, as_={alias})')

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -150,7 +150,7 @@ def smuggle_colab(
 ):
     # ADD DOCSTRING
     if installer_kwargs is None:
-        installer_args = {}
+        installer_kwargs = {}
 
     pkg_name = name.split('.')[0]
     onion = Onion(pkg_name, installer=installer,

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -17,13 +17,13 @@ __all__ = [
 
 
 import importlib
+import re
 import sys
 import warnings
-from pathlib import Path
 from subprocess import CalledProcessError
 
 from davos import davos
-from davos.core import Onion, prompt_input
+from davos.core import Onion, prompt_input, smuggle_statement_regex
 from davos.exceptions import DavosParserError, OnionTypeError, SmugglerError
 
 if davos.ipython_shell is not None:
@@ -117,12 +117,12 @@ def smuggle_colab(name, as_=None, **onion_kwargs):
         installer_stdout, exit_code = onion.install_package()
         # packages with C extensions (e.g., numpy, pandas) cannot be
         # reloaded within an interpreter session. If the package was
-        # previously imported in the current (even if not by user), get
-        # versions before & after reload, and if there's no change, warn
-        # about needing to reset runtime for changes to take effect with
-        # "RESTART RUNTIME" button in output. Elif unable to determine
-        # version both before and after reload, issue lower-priority
-        # warning about uncertainty
+        # previously imported in the current runtime (even if not by
+        # user), get versions before & after reload, and if there's no
+        # change, warn about needing to reset runtime for changes to
+        # take effect with "RESTART RUNTIME" button in output. Elif
+        # unable to determine version both before and after reload,
+        # issue lower-priority warning about uncertainty
         prev_imported_pkgs = get_updated_imported_pkgs(installer_stdout)
         # highest-level package should be dealt with last
         try:
@@ -188,178 +188,238 @@ def smuggle_colab(name, as_=None, **onion_kwargs):
 
 def smuggle_parser_colab(line):
     # ADD DOCSTRING
-    stripped = line.strip()
-    if (
-            'smuggle ' in line and
-            # ignore commented-out lines
-            not stripped.startswith('#') and
-            # if smuggle is not the first word, it must be preceded by
-            # a space. Helps handle weird edge cases, e.g.:
-            #   `self.unrelated_attr_that_endswith_smuggle = 1`
-            (stripped.startswith('smuggle ') or ' smuggle ' in stripped)
-    ):
-        indent_len = len(line) - len(line.lstrip(' '))
-        # need to handle lines with comments separately, before checking
-        # for characters (',', ';', etc.) in line so characters in
-        # comments don't cause false-positive
-        if '#' in stripped:
-            # have to deal with the possibility of:
-            #   ```
-            #   smuggle (b, # b onion comment
-            #            c, # c onion comment # non-onion comment
-            #            d) # d onion comment # non-onion comment # etc
-            #   ```
-            # and also:
-            #  ```
-            #   smuggle (    # could even be an arbitrary comment here...
-            #       b,       # b onion comment
-            #   # ... and even comments between lines...
-            #       c,       # c onion comment
-            #       d        # d onion comment # non-onion comment # etc
-            #   )            # ... or on an "empty" line
-            #   ```
-            # or even:
-            #   ```
-            #   smuggle (b,       # b onion comment
-            #            c,       # c onion comment
-            #            d)       # d onion comment # non-onion comment # etc
-            #   ```
-            # - only way this can happen is with parentheses & newlines,
-            #   so we can use that as a queue
-            # - on each line, all text before first # is real code
-            # - can only have one onion comment per module imported, so
-            # we can discount statements that don't start with 'smuggle'
-            if all(c in stripped for c in '()\n'):
-                if stripped.startswith('smuggle'):
-                    sub_lines = []
-                    for _line in stripped.splitlines():
-                        code, sep, comment = _line.partition('#')
-                        code = code.strip(', ')
-                        if code.endswith('(') or code == '' or code == ')':
-                            # - skip empty first lines, i.e. 'smuggle ('
-                            # - skip lines with no code, just comments
-                            # - skip empty last lines, i.e. ')'
-                            continue
-                        else:
-                            _line = f"smuggle {code.strip('() ')} {sep} {comment}"
-                            sub_lines.append(smuggle_parser_colab(_line))
-                elif stripped.startswith('from '):
-                    # can only have one onion comment per package, for
-                    # multiline, import from a single package, it can go
-                    # either on the first line (better) or the last line
-                    # (also allowed).
-                    # NOTE: if there is ANY comment on the first line,
-                    #  even if it is not an onion notation, the last
-                    #  line will not be looked at
-                    _lines = stripped.splitlines()
-                    code, _, comment = _lines[0].partition('#')
-                    pkg_name = code.split()[1]
-                    comment = comment.strip()
-                    if comment == '':
-                        comment = _lines[-1].partition('#')[2].strip()
-                    if comment == '':
-                        sep = ''
-                    else:
-                        sep = ' # '
-                    sub_lines = []
-                    _lines = stripped.split('smuggle (')[1].splitlines()
-                    for _line in _lines:
-                        _line = _line.split('#')[0].strip('), ')
-                        for name in _line.split(','):
-                            if name != '':
-                                _cmd = f'from {pkg_name} smuggle {name}'
-                                sub_lines.append(_cmd)
-                    # add onion comment to first statement so package
-                    # exists when the rest are run
-                    sub_lines[0] = f'{sub_lines[0]}{sep}{comment}'
-                    sub_lines = list(map(smuggle_parser_colab, sub_lines))
-                else:
-                    raise DavosParserError(
-                        "failed to parse multiline smuggle statement"
-                    )
-                line = '; '.join(sub_lines)
-            else:
-                # otherwise, there's only one onion comment
-                # TODO: a way to catch this, which is normally a SyntaxError:
-                #   ```
-                #   import a, \  # a onion comment
-                #          b, \  # b onion comment
-                #          c,    # c onion comment
-                #   ```
-                stripped, _, raw_onion = stripped.partition('#')
-                stripped = stripped.strip()
-                # currently in form: `smuggle(pack.age, as_=['<alias>'|None])`
-                base_smuggle_call = smuggle_parser_colab(stripped)
-                # drop any trailing non-onion comments
-                raw_onion = raw_onion.partition('#')[0]
-                # {param: value} kwargs dict for smuggle_colab()
-                peeled_onion = Onion.parse_onion_syntax(raw_onion)
-                kwargs_list = []
-                for k, v in peeled_onion.items():
-                    if isinstance(v, str):
-                        v = '"' + v + '"'
-                    kwargs_list.append(f'{k}={v}')
-                kwargs_fmt = ', '.join(kwargs_list)
-                # insert the kwargs before the closing parenthesis
-                line = f"{base_smuggle_call[:-1]}, {kwargs_fmt})"
-        elif ';' in stripped:
-            # handles semicolon-separated smuggle calls, e.g.:
-            #   `smuggle os.path; from pathlib smuggle Path; smuggle re`
-            # by running function on each call individually & re-joining
-            line = '; '.join(map(smuggle_parser_colab, stripped.split(';')))
-        elif ',' in stripped:
-            # handles comma-separated list of packages/modules/functions
-            # to smuggle
-            if stripped.startswith('from '):
-                # smuggling multiple names from same package, e.g.:
-                #   `from os.path smuggle dirname, join as opj, realpath`
-                # is transformed internally into multiple smuggle calls:
-                #   `smuggle os.path.dirname as dirname; smuggle os....`
-                from_cmd, names = stripped.split(' smuggle ')
-                names = names.strip('()\n\t ').split(',')
-                all_cmds = [f'{from_cmd} smuggle {name}' for name in names]
-            else:
-                # smuggling multiple packages at once, e.g.:
-                #   `smuggle collections.abc as abc, json, os`
-                # is transformed into multiple smuggle calls, e.g.:
-                #   `smugle collections.abc as abc; smuggle json, sm...`
-                names = stripped.replace('smuggle ', '').split(',')
-                all_cmds = [f'smuggle {name}' for name in names]
-            line = '; '.join(map(smuggle_parser_colab, all_cmds))
-        elif stripped.startswith('from '):
-            # handles smuggle calls in formats like, e.g.:
-            #   `from os.path smuggle join as opj`
-            # by transforming them into, e.g.:
-            #   `smuggle os.path.join as opj
-            # This grammar can sometimes fail with the builtin import
-            # statement, e.g.:
-            #   `import numpy.array as array` # -> ModuleNotFoundError
-            # but IPython.utils.importstring.import_item always succeeds
-            pkg_name, name = stripped.split(' smuggle ')
-            pkg_name = pkg_name.replace('from ', '').strip()
-            if ' as ' in name:
-                name, as_ = name.split(' as ')
-            else:
-                as_ = name
-            name = name.strip('()\n\t ')
-            as_ = as_.strip()
-            full_name = f'{pkg_name}.{name}'
-            line = f'smuggle("{full_name}", as_="{as_}")'
+    match = smuggle_statement_regex.match(line)
+    if match is None:
+        return line
+
+    matched_groups = match.groupdict()
+    smuggle_chars = matched_groups['FULL_CMD']
+    before_chars, after_chars = line.split(smuggle_chars)
+    cmd_prefix, to_smuggle = smuggle_chars.split('smuggle ', maxsplit=1)
+
+    if cmd_prefix:
+        # cmd_prefix == 'from <package[.module[...]]> '
+        is_from_statement = True
+        onion_chars = matched_groups['FROM_ONION'] or matched_groups['FROM_ONION_1']
+        has_semicolon_sep = matched_groups['FROM_SEMICOLON_SEP'] is not None
+        pkg_name = cmd_prefix.split()[1] + '.'
+        to_smuggle = re.sub(r'[()]|\s*\#.*$\s*', ' ', to_smuggle, flags=re.MULTILINE)
+        to_smuggle = to_smuggle.rstrip(', ')
+    else:
+        # cmd_prefix == ''
+        is_from_statement = False
+        onion_chars = matched_groups['ONION']
+        has_semicolon_sep = matched_groups['SEMICOLON_SEP'] is not None
+
+    kwargs_str = ''
+    if has_semicolon_sep:
+        after_chars = '; ' + smuggle_parser_colab(after_chars.lstrip('; '))
+    elif onion_chars is not None:
+        to_smuggle = to_smuggle.replace(onion_chars, '').rstrip()
+        onion_kwargs = Onion.parse_onion_syntax(onion_chars.lstrip('# '))
+        for arg, val in onion_kwargs.items():
+            if isinstance(val, str):
+                val = f'"{val}"'
+            kwargs_str += f', {arg}={val}'
+
+    smuggle_funcs = []
+    names_aliases = to_smuggle.split(',')
+    for na in names_aliases[1:]:
+        if ' as ' in names_aliases:
+            name, alias = na.split(' as ')
+            name, alias = name.strip(), alias.strip()
+        elif is_from_statement:
+            alias = na.strip()
+            name = cmd_prefix.split()[1] + '.' + alias
         else:
-            # standard smuggle call, e.g.:
-            #   `smuggle pandas as pd`
-            pkg_name = stripped.replace('smuggle ', '')
-            if ' as ' in pkg_name:
-                pkg_name, as_ = pkg_name.split(' as ')
-                # add quotes here so None can be passed without them
-                as_ = f'"{as_.strip()}"'
-            else:
-                as_ = None
-            pkg_name = pkg_name.strip('()\n\t ')
-            line = f'smuggle("{pkg_name}", as_={as_})'
-        # restore original indent
-        line = ' ' * indent_len + line
-    return line
+            name, alias = na.strip(), None
+        smuggle_funcs.append(f'smuggle(name={name}, as_={alias})')
+    smuggle_funcs[0] = smuggle_funcs[0][:-1] + kwargs_str + ')'
+    return before_chars + '; '.join(smuggle_funcs) + after_chars
+
+#
+# def smuggle_parser_colab(line):
+#     # ADD DOCSTRING
+#     stripped = line.strip()
+#     if 'smuggle ' not in line:# or (not stripped.startswith('smuggle') and ):
+#         return line
+#
+#     indent_len = len(line) - len(line.lstrip(' '))
+#     if '#' in stripped:
+#         if stripped.index('#') < stripped.index('smuggle '):
+#             return line
+#         elif all(c in stripped for c in '()\n'):
+#             # - handles syntax for using a single statement to smuggle
+#             #   multiple items joined via implicit line continuation
+#             #   inside parentheses, e.g.:
+#             #    ```
+#             #    smuggle (a,    # pkg a onion comment # unrelated comment
+#             #             b,    # pkg b onion comment
+#             #             c)    # pkg c onion comment
+#             #
+#             #    smuggle (      # unrelated comment here is valid
+#             #        d,         # pkg d onion comment
+#             #        e,     # can be any amount of space before comment
+#             #    # comments between lines are also valid
+#             #        f          # pkg f onion comment
+#             #    )              # unrelated comment here also valid
+#             #
+#             #    from g smuggle (    # pkg g onion comment
+#             #        h,
+#             #        i,
+#             #        j
+#             #    )
+#             #    ```
+#             # - Multiline statements are only possible using implicit
+#             # line continuation. Backslash continuation gets passed to
+#             # transformer as a single line
+#             if stripped.startswith('smuggle'):
+#                 # If items are different packages, each could have its
+#                 # own onion comment
+#                 sub_lines = []
+#                 for _line in stripped.splitlines():
+#                     code, sep, comment = _line.partition('#')
+#                     code = code.strip(', ')
+#                     if code.endswith('(') or code == '' or code == ')':
+#                         # - skip empty first lines, i.e. 'smuggle ('
+#                         # - skip lines with no code, just comments
+#                         # - skip empty last lines, i.e. ')'
+#                         continue
+#                     else:
+#                         _line = f"smuggle {code.strip('() ')} {sep} {comment}"
+#                         sub_lines.append(smuggle_parser_colab(_line))
+#             elif stripped.startswith('from '):
+#                 # multiline import of items from the same package can
+#                 # have only a single onion comment. Can go on either the
+#                 # first line (preferred) or last line (also allowed).
+#                 # NOTE: if there is ANY comment on the first line, even
+#                 #  if it is not an onion notation, the last line will
+#                 #  not be looked at
+#                 _lines = stripped.splitlines()
+#                 code, _, comment = _lines[0].partition('#')
+#                 pkg_name = code.split()[1]
+#                 comment = comment.strip()
+#                 if comment == '':
+#                     comment = _lines[-1].partition('#')[2].strip()
+#                 if comment == '':
+#                     sep = ''
+#                 else:
+#                     sep = ' # '
+#                 sub_lines = []
+#                 _lines = stripped.split('smuggle (')[1].splitlines()
+#                 for _line in _lines:
+#                     _line = _line.split('#')[0].strip('), ')
+#                     for name in _line.split(','):
+#                         if name != '':
+#                             _cmd = f'from {pkg_name} smuggle {name}'
+#                             sub_lines.append(_cmd)
+#                 # add onion comment to first statement so package
+#                 # exists when the rest are run
+#                 sub_lines[0] = f'{sub_lines[0]}{sep}{comment}'
+#                 sub_lines = list(map(smuggle_parser_colab, sub_lines))
+#             else:
+#                 raise DavosParserError(
+#                     "failed to parse multiline smuggle statement"
+#                 )
+#             line = '; '.join(sub_lines)
+#         else:
+#             # otherwise, there's only one onion comment
+#             # TODO: a way to catch this, which is invalid and normally
+#             #  raises a SyntaxError:
+#             #   ```
+#             #   import a, \  # a onion comment
+#             #          b, \  # b onion comment
+#             #          c,    # c onion comment
+#             #   ```
+#             stripped, _, raw_onion = stripped.partition('#')
+#             stripped = stripped.strip()
+#             # currently in form: `smuggle(pack.age, as_=['<alias>'|None])`
+#             base_smuggle_call = smuggle_parser_colab(stripped)
+#             # drop any trailing non-onion comments
+#             raw_onion = raw_onion.partition('#')[0]
+#             # {param: value} kwargs dict for smuggle_colab()
+#             peeled_onion = Onion.parse_onion_syntax(raw_onion)
+#             kwargs_list = []
+#             for k, v in peeled_onion.items():
+#                 if isinstance(v, str):
+#                     v = '"' + v + '"'
+#                 kwargs_list.append(f'{k}={v}')
+#             kwargs_fmt = ', '.join(kwargs_list)
+#             # insert the kwargs before the closing parenthesis
+#             line = f"{base_smuggle_call[:-1]}, {kwargs_fmt})"
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#         elif ';' in stripped:
+#             # handles semicolon-separated smuggle calls, e.g.:
+#             #   `smuggle os.path; from pathlib smuggle Path; smuggle re`
+#             # by running function on each call individually & re-joining
+#             line = '; '.join(map(smuggle_parser_colab, stripped.split(';')))
+#         elif ',' in stripped:
+#             # handles comma-separated list of packages/modules/functions
+#             # to smuggle
+#             if stripped.startswith('from '):
+#                 # smuggling multiple names from same package, e.g.:
+#                 #   `from os.path smuggle dirname, join as opj, realpath`
+#                 # is transformed internally into multiple smuggle calls:
+#                 #   `smuggle os.path.dirname as dirname; smuggle os....`
+#                 from_cmd, names = stripped.split(' smuggle ')
+#                 names = names.strip('()\n\t ').split(',')
+#                 all_cmds = [f'{from_cmd} smuggle {name}' for name in names]
+#             else:
+#                 # smuggling multiple packages at once, e.g.:
+#                 #   `smuggle collections.abc as abc, json, os`
+#                 # is transformed into multiple smuggle calls, e.g.:
+#                 #   `smugle collections.abc as abc; smuggle json, sm...`
+#                 names = stripped.replace('smuggle ', '').split(',')
+#                 all_cmds = [f'smuggle {name}' for name in names]
+#             line = '; '.join(map(smuggle_parser_colab, all_cmds))
+#         elif stripped.startswith('from '):
+#             # handles smuggle calls in formats like, e.g.:
+#             #   `from os.path smuggle join as opj`
+#             # by transforming them into, e.g.:
+#             #   `smuggle os.path.join as opj
+#             # This grammar can sometimes fail with the builtin import
+#             # statement, e.g.:
+#             #   `import numpy.array as array` # -> ModuleNotFoundError
+#             # but IPython.utils.importstring.import_item always succeeds
+#             pkg_name, name = stripped.split(' smuggle ')
+#             pkg_name = pkg_name.replace('from ', '').strip()
+#             if ' as ' in name:
+#                 name, as_ = name.split(' as ')
+#             else:
+#                 as_ = name
+#             name = name.strip('()\n\t ')
+#             as_ = as_.strip()
+#             full_name = f'{pkg_name}.{name}'
+#             line = f'smuggle("{full_name}", as_="{as_}")'
+#         else:
+#             # standard smuggle call, e.g.:
+#             #   `smuggle pandas as pd`
+#             pkg_name = stripped.replace('smuggle ', '')
+#             if ' as ' in pkg_name:
+#                 pkg_name, as_ = pkg_name.split(' as ')
+#                 # add quotes here so None can be passed without them
+#                 as_ = f'"{as_.strip()}"'
+#             else:
+#                 as_ = None
+#             pkg_name = pkg_name.strip('()\n\t ')
+#             line = f'smuggle("{pkg_name}", as_={as_})'
+#         # restore original indent
+#         line = ' ' * indent_len + line
+#     return line
 
 
 smuggle_colab._register = register_smuggler_colab

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -13,7 +13,8 @@ __all__ = [
     'activate_parser_colab',
     'deactivate_parser_colab',
     'run_shell_command_colab',
-    'smuggle_colab'
+    'smuggle_colab',
+    'smuggle_parser_colab'
 ]
 
 
@@ -39,29 +40,6 @@ if davos.ipython_shell is not None:
         from google.colab._pip import (
             _previously_imported_packages as get_updated_imported_pkgs
         )
-
-
-# noinspection PyDeprecation
-def deactivate_parser_colab():
-    """
-    Stops the `davos` parser from running for all future cells
-    (including the current cell) until reactivated.
-
-    Notes
-    -----
-    *See notes for `activate_parser_colab()`*
-    """
-    colab_shell = davos.ipython_shell
-    splitter_xforms = colab_shell.input_splitter.python_line_transforms
-    manager_xforms = colab_shell.input_transformer_manager.python_line_transforms
-    for xform in splitter_xforms:
-        if xform.func is smuggle_parser_colab:
-            splitter_xforms.remove(xform)
-            break
-    for xform in manager_xforms:
-        if xform.func is smuggle_parser_colab:
-            manager_xforms.remove(xform)
-            break
 
 
 def activate_parser_colab():
@@ -95,6 +73,29 @@ def activate_parser_colab():
         manager_xforms.append(smuggle_transformer())
 
     colab_shell.user_ns['smuggle'] = smuggle_colab
+
+
+# noinspection PyDeprecation
+def deactivate_parser_colab():
+    """
+    Stops the `davos` parser from running for all future cells
+    (including the current cell) until reactivated.
+
+    Notes
+    -----
+    *See notes for `activate_parser_colab()`*
+    """
+    colab_shell = davos.ipython_shell
+    splitter_xforms = colab_shell.input_splitter.python_line_transforms
+    manager_xforms = colab_shell.input_transformer_manager.python_line_transforms
+    for xform in splitter_xforms:
+        if xform.func is smuggle_parser_colab:
+            splitter_xforms.remove(xform)
+            break
+    for xform in manager_xforms:
+        if xform.func is smuggle_parser_colab:
+            manager_xforms.remove(xform)
+            break
 
 
 def run_shell_command_colab(command):

--- a/davos/core.py
+++ b/davos/core.py
@@ -80,10 +80,10 @@ class Onion:
             self.install_name = package_name
             self.version_spec = ''
             return
-        
+
         full_spec = installer_kwargs.pop('spec').strip("'\"")
         self.is_editable = installer_kwargs.pop('editable')
-        self.verbosity = installer_kwargs.pop('verbosity')
+        self.verbosity = installer_kwargs.pop('verbosity', 0)
         self.installer_kwargs = installer_kwargs
         if '+' in full_spec:
             # INSTALLING FROM LOCAL/REMOTE VCS:

--- a/davos/core.py
+++ b/davos/core.py
@@ -58,17 +58,10 @@ class Onion:
             # 'subdirectory': None,
             # 'build': None
         }
-        installer, sep, arg_str = comment_text.partition(':')
-        if installer == 'conda':
-            peeled_onion['installer'] = 'conda'
-        elif installer != 'pip' and installer != 'pypi':
-            # TODO: current smuggle_statement_regex doesn't allow this possibility
-            # unrelated, non-onion inline comment
-            return peeled_onion
-        if sep == '':
-            # TODO: current smuggle_statement_regex doesn't allow this possibility
-            # no colon, no install arguments other than installer name
-            return peeled_onion
+        installer, arg_str = comment_text.split(':', maxsplit=1)
+        # not yet supported
+        # if installer == 'conda':
+        #     peeled_onion['installer'] = 'conda'
         version_spec, _, arg_str = arg_str.strip().partition(' ')
         # split on ',' to account for 'pkg>=1.0,<=2.0' syntax
         first_subspec = version_spec.split(',')[0]
@@ -118,13 +111,13 @@ class Onion:
         #  and module is already in sys.modules?
         if installer == 'pip' or installer == 'pypi':
             self.install_package = self._pip_install_package
-        elif installer == 'conda':
-            self.install_package = self._conda_install_package
+        # elif installer == 'conda':
+        #     self.install_package = self._conda_install_package
         else:
             # here to handle user calling smuggle() *function* directly
             raise InstallerError(
                 f"Unsupported installer: '{installer}'. Currently supported "
-                "installers are 'pip' and 'conda'"
+                "installers are 'pip'"# and 'conda'"
             )
         self.import_name = import_name
         self.installer = installer
@@ -361,9 +354,9 @@ smuggle_statement_regex = re.compile((
 # (?P<OPEN_PARENS>\()?(?(OPEN_PARENS)(?: *(?:[a-zA-Z]\w*(?: +as +[a-zA-Z
 # ]\w*)? *(?:, *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *)*,? *)?(?:(?P<FROM_O
 # NION_1>\#+ *pip:[^#]+[^#\s]) *(?m:\#+.*$)?|(?m:\#+.*$)|(?m:$)|(?P<CLOS
-# E_PARENS>\)))(?(CLOSE_PARENS)|(?:\s*(?:[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*
-# )? *(?:, *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *)*[^)\n]*| *(?m:\#+.*$)|\
-# n *))*\)))|[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?(?: *, *[a-zA-Z]\w*(?: +as
-#  +[a-zA-Z]\w*)?)*)(?P<FROM_SEMICOLON_SEP>(?= *; *(?:smuggle|from)))?(?
-# (FROM_SEMICOLON_SEP)|(?(FROM_ONION_1)|(?: *(?=\#+ *pip:[^#]+[^#\s])(?P
-# <FROM_ONION>\#+ *pip:[^#]+[^#\s]))?))))
+# E_PARENS_FIRSTLINE>\)))(?(CLOSE_PARENS_FIRSTLINE)|(?:\s*(?:[a-zA-Z]\w*
+# (?: +as +[a-zA-Z]\w*)? *(?:, *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *)*[^)
+# \n]*| *(?m:\#+.*$)|\n *))*\)))|[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?(?: *,
+#  *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?)*)(?P<FROM_SEMICOLON_SEP>(?= *; *(
+# ?:smuggle|from)))?(?(FROM_SEMICOLON_SEP)|(?(FROM_ONION_1)|(?: *(?=\#+
+# *pip:[^#]+[^#\s])(?P<FROM_ONION>\#+ *pip:[^#]+[^#\s]))?))))

--- a/davos/core.py
+++ b/davos/core.py
@@ -5,7 +5,7 @@ IPython/Jupyter Notebook).
 """
 
 
-__all__ = ['Onion', 'prompt_input']
+__all__ = ['Onion', 'prompt_input', 'smuggle_statement_regex']
 
 
 import re

--- a/davos/core.py
+++ b/davos/core.py
@@ -161,30 +161,17 @@ class Onion:
         return False
 
     def _pip_install_package(self):
-        # TODO: would be more efficient to use nullcontext here as long
-        #  as it works in ipynb
-        # TODO: add support for all kinds of non-index installs (see
-        #  https://pip.pypa.io/en/stable/reference/pip_install/)
-        install_name = self.install_name
-        if '+' in install_name:
-            vcs_field_sep= '#'
-            if self.egg is not None:
-                install_name += vcs_field_sep + self.egg
-                vcs_field_sep = '&'
-            if self.subdirectory is not None:
-                install_name += vcs_field_sep + self.subdirectory
-        elif self.version_spec is not None:
-            install_name += self.version_spec
-        cmd_str = f'pip install {self.installer_args} {install_name}'
+        cmd_str = f'pip install {self.args_str}'
+        live_stdout = self.verbosity > -3
         try:
-            stdout, exit_code = davos.run_shell_command(cmd_str)
+            stdout, exit_code = davos.run_shell_command(cmd_str,
+                                                        live_stdout=live_stdout)
         except CalledProcessError as e:
             err_msg = (f"the command '{e.cmd}' returned a non-zero "
                        f"exit code: {e.returncode}. See above output "
                        f"for details")
             raise InstallerError(err_msg, e)
-        else:
-            return stdout, exit_code
+        return stdout, exit_code
 
     def _conda_install_package(self):
         raise NotImplementedError(

--- a/davos/core.py
+++ b/davos/core.py
@@ -21,7 +21,6 @@ from davos import davos
 from davos.exceptions import (
     InstallerError,
     OnionParserError,
-    OnionSyntaxError,
     ParserNotImplementedError
 )
 from davos.parsers import pip_parser

--- a/davos/core.py
+++ b/davos/core.py
@@ -11,8 +11,8 @@ __all__ = ['Onion', 'prompt_input', 'smuggle_statement_regex']
 import re
 from subprocess import CalledProcessError
 
-import packaging
 import pkg_resources
+from packaging.requirements import InvalidRequirement
 
 from davos import davos
 from davos.exceptions import (
@@ -164,7 +164,7 @@ class Onion:
                 pkg_resources.VersionConflict,
                 # version_spec is invalid or pkg_resources couldn't
                 # parse it
-                packaging.requirements.InvalidRequirement
+                InvalidRequirement
             ):
                 return False
             else:

--- a/davos/core.py
+++ b/davos/core.py
@@ -9,6 +9,7 @@ __all__ = ['Onion', 'prompt_input', 'smuggle_statement_regex']
 
 
 import re
+import sys
 from subprocess import CalledProcessError
 
 import pkg_resources
@@ -189,6 +190,14 @@ class Onion:
                        f"exit code: {e.returncode}. See above output "
                        f"for details")
             raise InstallerError(err_msg, e)
+        # if installed in a specific directory, make sure it's in the
+        # module search path so import machinery will find it
+        install_dir = self.installer_kwargs.get('src')
+        if install_dir is None:
+            install_dir = self.installer_kwargs.get('target')
+        if install_dir is not None and install_dir not in sys.path:
+            sys.path.insert(0, install_dir)
+
         return stdout, exit_code
 
     def _conda_install_package(self):

--- a/davos/core.py
+++ b/davos/core.py
@@ -10,9 +10,9 @@ __all__ = ['Onion', 'prompt_input']
 
 import re
 from pathlib import Path
+from packaging.requirements import InvalidRequirement
 from pkg_resources import (DistributionNotFound, find_distributions,
-                           get_distribution, RequirementParseError,
-                           VersionConflict)
+                           get_distribution, VersionConflict)
 from subprocess import CalledProcessError
 
 from davos import davos
@@ -163,11 +163,11 @@ class Onion:
                 dist_spec += self.version_spec
             try:
                 get_distribution(dist_spec)
-            except (DistributionNotFound, VersionConflict, RequirementParseError):
+            except (DistributionNotFound, VersionConflict, InvalidRequirement):
                 # DistributionNotFound: package is not installed
                 # VersionConflict: package is installed, but installed
                 #   version doesn't fit requested version constraints
-                # RequirementParserError: version_spec is invalid or
+                # InvalidRequirement: version_spec is invalid or
                 # pkg_resources couldn't parse it
                 return False
             else:

--- a/davos/core.py
+++ b/davos/core.py
@@ -39,16 +39,17 @@ class Onion:
         if installer == 'pip':
             parser = pip_parser
         elif installer == 'conda':
+            msg = "smuggling packages via conda is not yet supported"
             raise ParserNotImplementedError(
-                "smuggling packages via conda is not yet supported"
+                msg, target_text=onion_text,
+                target_offset=onion_text.index('conda')
             )
         else:
             # theoretically not possible to get here given regex parser,
             # but include as a failsafe for completeness
-            raise OnionParserError(
-                "An unexpected error occurred while trying to parse onion "
-                f"comment: {onion_text}"
-            )
+            msg = ("An unexpected error occurred while trying to parse onion "
+                   f"comment: {onion_text}")
+            raise OnionParserError(msg, target_text=onion_text)
         installer_kwargs = vars(parser.parse_args(args_str.split()))
         # arg_str could potentially have both single and double quotes
         # in it, so triple quote to be safe

--- a/davos/core.py
+++ b/davos/core.py
@@ -58,7 +58,7 @@ class Onion:
                 f"comment: {onion_text}"
             )
         installer_kwargs = vars(parser.parse_args(args_str.split()))
-        # `arg_str` could potentially have both single and double quotes
+        # arg_str could potentially have both single and double quotes
         # in it, so triple quote to be safe
         return f'"{installer}"', f'"""{args_str}"""', installer_kwargs
 

--- a/davos/core.py
+++ b/davos/core.py
@@ -153,7 +153,7 @@ class Onion:
             # line is just being rerun)
             return True
         elif '/' not in self.install_name:
-            full_spec = self.install_name + self.version_spec
+            full_spec = self.install_name + self.version_spec.replace("'", "")
             try:
                 pkg_resources.get_distribution(full_spec)
             except (
@@ -172,7 +172,8 @@ class Onion:
         return False
 
     def _pip_install_package(self):
-        cmd_str = f'pip install {self.args_str}'
+        args = self.args_str.replace("<", "'<'").replace(">", "'>'")
+        cmd_str = f'pip install {args}'
         live_stdout = self.verbosity > -3
         try:
             stdout, exit_code = davos.run_shell_command(cmd_str,

--- a/davos/core.py
+++ b/davos/core.py
@@ -264,7 +264,7 @@ _smuggle_subexprs['as_re'] = fr' +as +{_smuggle_subexprs["name_re"]}'
 
 smuggle_statement_regex = re.compile((
     r'^\s*'                                                               # match only if statement is first non-whitespace chars
-    r'(?<FULL_CMD>'                                                       # capture full text of command in named group
+    r'(?P<FULL_CMD>'                                                       # capture full text of command in named group
         r'(?:'                                                            # first valid syntax:
             r'smuggle +{qualname_re}(?:{as_re})?'                         # match 'smuggle' + pkg name + optional alias
             r'(?:'                                                        # match the following:

--- a/davos/core.py
+++ b/davos/core.py
@@ -190,14 +190,6 @@ class Onion:
                        f"exit code: {e.returncode}. See above output "
                        f"for details")
             raise InstallerError(err_msg, e)
-        # if installed in a specific directory, make sure it's in the
-        # module search path so import machinery will find it
-        install_dir = self.installer_kwargs.get('src')
-        if install_dir is None:
-            install_dir = self.installer_kwargs.get('target')
-        if install_dir is not None and install_dir not in sys.path:
-            sys.path.insert(0, install_dir)
-
         return stdout, exit_code
 
     def _conda_install_package(self):

--- a/davos/core.py
+++ b/davos/core.py
@@ -9,11 +9,9 @@ __all__ = ['Onion', 'prompt_input']
 
 
 import re
-from pathlib import Path
 from packaging.requirements import InvalidRequirement
 from pkg_resources import (
     DistributionNotFound,
-    find_distributions,
     get_distribution,
     VersionConflict
 )
@@ -57,7 +55,7 @@ class Onion:
         # in it, so triple quote to be safe
         return f'"{installer}"', f'"""{args_str}"""', installer_kwargs
 
-    def __init__(self, package_name, installer='pip', args_str='', **installer_kwargs):
+    def __init__(self, package_name, installer, args_str, **installer_kwargs):
         # ADD DOCSTRING
         self.import_name = package_name
         if installer == 'pip':
@@ -75,6 +73,7 @@ class Onion:
         self.args_str = args_str
         full_spec = installer_kwargs.pop('spec').strip("'\"")
         self.is_editable = installer_kwargs.pop('editable')
+        self.verbosity = installer_kwargs.pop('verbosity')
         self.installer_kwargs = installer_kwargs
         self.build = None
         if '+' in full_spec:

--- a/davos/core.py
+++ b/davos/core.py
@@ -18,8 +18,7 @@ from davos import davos
 from davos.exceptions import (
     InstallerError,
     OnionParserError,
-    ParserNotImplementedError,
-    SmugglerError
+    ParserNotImplementedError
 )
 from davos.parsers import pip_parser
 

--- a/davos/core.py
+++ b/davos/core.py
@@ -70,12 +70,21 @@ class Onion:
                 f"Unsupported installer: '{installer}'. Currently supported "
                 "installers are:\n\t'pip'"  # and 'conda'"
             )
+        self.build = None
         self.args_str = args_str
+        if args_str == '':
+            # bare smuggle statement without onion comment
+            self.is_editable = False
+            self.verbosity = 0
+            self.installer_kwargs = {}
+            self.install_name = package_name
+            self.version_spec = ''
+            return
+        
         full_spec = installer_kwargs.pop('spec').strip("'\"")
         self.is_editable = installer_kwargs.pop('editable')
         self.verbosity = installer_kwargs.pop('verbosity')
         self.installer_kwargs = installer_kwargs
-        self.build = None
         if '+' in full_spec:
             # INSTALLING FROM LOCAL/REMOTE VCS:
             #   self.install_name is the VCS program + '+' + absolute

--- a/davos/core.py
+++ b/davos/core.py
@@ -9,13 +9,10 @@ __all__ = ['Onion', 'prompt_input', 'smuggle_statement_regex']
 
 
 import re
-from packaging.requirements import InvalidRequirement
-from pkg_resources import (
-    DistributionNotFound,
-    get_distribution,
-    VersionConflict
-)
 from subprocess import CalledProcessError
+
+import packaging
+import pkg_resources
 
 from davos import davos
 from davos.exceptions import (
@@ -156,14 +153,19 @@ class Onion:
             # line is just being rerun)
             return True
         elif '/' not in self.install_name:
+            full_spec = self.install_name + self.version_spec
             try:
-                get_distribution(self.install_name + self.version_spec)
-            except (DistributionNotFound, VersionConflict, InvalidRequirement):
-                # - DistributionNotFound: package is not installed
-                # - VersionConflict: package is installed, but installed
-                #   version doesn't fit requested version constraints
-                # - InvalidRequirement: version_spec is invalid or
-                #   pkg_resources couldn't parse it
+                pkg_resources.get_distribution(full_spec)
+            except (
+                # requested package is not installed
+                pkg_resources.DistributionNotFound,
+                # package is installed, but installed version doesn't
+                # fit requested version constraints
+                pkg_resources.VersionConflict,
+                # version_spec is invalid or pkg_resources couldn't
+                # parse it
+                packaging.requirements.InvalidRequirement
+            ):
                 return False
             else:
                 return True

--- a/davos/core.py
+++ b/davos/core.py
@@ -18,7 +18,8 @@ from davos import davos
 from davos.exceptions import (
     InstallerError,
     OnionParserError,
-    ParserNotImplementedError
+    ParserNotImplementedError,
+    SmugglerError
 )
 from davos.parsers import pip_parser
 
@@ -172,7 +173,13 @@ class Onion:
         return False
 
     def _pip_install_package(self):
-        args = self.args_str.replace("<", "'<'").replace(">", "'>'")
+        # TODO: default behavior (no onion comment) is currently to try
+        #  to simply pip-install the package name. Could raise an
+        #  exception instead?
+        if self.args_str == '':
+            args = self.install_name
+        else:
+            args = self.args_str.replace("<", "'<'").replace(">", "'>'")
         cmd_str = f'pip install {args}'
         live_stdout = self.verbosity > -3
         try:

--- a/davos/core.pyi
+++ b/davos/core.pyi
@@ -1,3 +1,4 @@
+from re import Pattern
 from typing import Literal, Optional
 
 InputOpts = Literal['y', 'yes', 'n', 'no']
@@ -46,3 +47,5 @@ def prompt_input(
 #
 class Onion(object):
     pass
+
+smuggle_statement_regex: Pattern

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -55,6 +55,9 @@ class DavosParserError(SyntaxError, DavosError):
         #  - `flot` is a 4-tuple of (**f**ilename, **l**ineno,
         #    **o**ffset, **t**ext) passed to the SyntaxError
         #    constructor.
+
+        # TODO: this may be a lot easier using sys.exc_info(),
+        #  inspect.stack(), inspect.getframeinfo(), etc.
         if target_text is None:
             flot = (None, None, None, None)
         else:

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -1,4 +1,4 @@
-from argparse import _get_action_name, ArgumentError
+from argparse import ArgumentError
 from subprocess import CalledProcessError
 
 from davos import davos

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -4,6 +4,17 @@ from subprocess import CalledProcessError
 from davos import davos
 
 
+__all__ = [
+    'DavosError',
+    'DavosParserError',
+    'OnionParserError',
+    'OnionArgumentError',
+    'ParserNotImplementedError',
+    'SmugglerError',
+    'InstallerError'
+]
+
+
 class DavosError(Exception):
     pass
 
@@ -75,14 +86,6 @@ class OnionParserError(DavosParserError):
     pass
 
 
-class ParserNotImplementedError(OnionParserError, NotImplementedError):
-    """
-    A version of NotImplementedError that can be raised during IPython
-    input transformation step because it inherits from SyntaxError
-    """
-    pass
-
-
 class OnionArgumentError(ArgumentError, OnionParserError):
     def __init__(self, msg=None, argument=None, onion_txt=None, *args):
         if (
@@ -106,6 +109,14 @@ class OnionArgumentError(ArgumentError, OnionParserError):
         OnionParserError.__init__(self, msg=msg, target_text=onion_txt,
                                   target_offset=target_offset, *args)
         self.argument_name = argument
+
+
+class ParserNotImplementedError(OnionParserError, NotImplementedError):
+    """
+    A version of NotImplementedError that can be raised during IPython
+    input transformation step because it inherits from SyntaxError
+    """
+    pass
 
 
 class SmugglerError(DavosError):

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -19,6 +19,43 @@ class DavosParserError(DavosError, SyntaxError):
     pass
 
 
+class OnionParserError(DavosParserError):
+    """general class for errors related to the Onion structure/object"""
+    pass
+
+
+class ParserNotImplementedError(OnionParserError, NotImplementedError):
+    """
+    A version of NotImplementedError that can be raised during IPython
+    input transformation step because it inherits from SyntaxError
+    """
+    pass
+
+
+class OnionArgumentError(ArgumentError, OnionParserError):
+    # class analogous to argparse.ArgumentError, but for invalid
+    # arguments passed in Onion construct
+    def __init__(self, message):
+        super().__init__(None, message)
+        if message.startswith('argument '):
+            split_message = message.split()
+            self.argument_name = split_message[1].rstrip(':')
+            self.message = ' '.join(split_message[2:])
+
+
+class OnionSyntaxError(OnionParserError):
+    # class analogous to SyntaxError, but for invalid Syntax in Onion
+    # construct
+    def __init__(self, msg, *args, filename=None, lineno=None, offset=None):
+        # TODO: format kwargs into tuple to init super() with correct
+        #  format to raise at specific location, see
+        #  https://stackoverflow.com/questions/33717804/python-raise-syntaxerror-with-lineno
+        super().__init__(msg, *args)
+        self.filename = filename
+        self.lineno = lineno
+        self.offset = offset
+
+
 class SmugglerError(DavosError):
     """class for errors raised during the smuggle step"""
     pass
@@ -65,32 +102,3 @@ class InstallerError(SmugglerError, CalledProcessError):
 
     def __str__(self):
         return self.msg + '\n\t' + super().__str__()
-
-
-class OnionParserError(DavosParserError):
-    """general class for errors related to the Onion structure/object"""
-    pass
-
-
-class OnionArgumentError(ArgumentError, OnionParserError):
-    # class analogous to argparse.ArgumentError, but for invalid
-    # arguments passed in Onion construct
-    def __init__(self, message):
-        super().__init__(None, message)
-        if message.startswith('argument '):
-            split_message = message.split()
-            self.argument_name = split_message[1].rstrip(':')
-            self.message = ' '.join(split_message[2:])
-
-
-class OnionSyntaxError(OnionParserError):
-    # class analogous to SyntaxError, but for invalid Syntax in Onion
-    # construct
-    def __init__(self, msg, *args, filename=None, lineno=None, offset=None):
-        # TODO: format kwargs into tuple to init super() with correct
-        #  format to raise at specific location, see
-        #  https://stackoverflow.com/questions/33717804/python-raise-syntaxerror-with-lineno
-        super().__init__(msg, *args)
-        self.filename = filename
-        self.lineno = lineno
-        self.offset = offset

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -82,10 +82,6 @@ class OnionArgumentError(ArgumentError, OnionParserError):
             self.argument_name = split_message[1].rstrip(':')
             self.message = ' '.join(split_message[2:])
 
-class OnionValueError(OnionParserError, ValueError):
-    # class analogous to ValueError, but for bad values passed to Onion
-    # construct params
-    pass
 
 class OnionSyntaxError(OnionParserError):
     # class analogous to SyntaxError, but for invalid Syntax in Onion

--- a/davos/exceptions.py
+++ b/davos/exceptions.py
@@ -100,14 +100,20 @@ class OnionArgumentError(ArgumentError, OnionParserError):
             argument = split_msg[1].rstrip(':')
             msg = ' '.join(split_msg[2:])
         if (onion_txt is not None) and (argument is not None):
-            try:
-                target_offset = onion_txt.index(argument)
-            except IndexError:
+            # default sorting is alphabetical where '--a' comes before
+            # '-a', so long option name will always be checked first,
+            # which is what we want
+            for aname in sorted(argument.split('/')):
+                if aname in onion_txt:
+                    target_offset = onion_txt.index(aname)
+                    break
+            else:
                 target_offset = 0
         else:
             target_offset = 0
-        # both `argparse.ArgumentError` and `SyntaxError` are non-cooperative,
-        # so need to initialize them separately rather than via call to super()
+        # both `argparse.ArgumentError` and `SyntaxError` are
+        # non-cooperative, so need to initialize them separately rather
+        # than just running through the MRO via a call to super()
         ArgumentError.__init__(self, argument=None, message=msg)
         OnionParserError.__init__(self, msg=msg, target_text=onion_txt,
                                   target_offset=target_offset, *args)

--- a/davos/jupyter.py
+++ b/davos/jupyter.py
@@ -1,3 +1,6 @@
+# TODO: add module docstring
+
+
 __all__ = [
     'register_smuggler_jupyter',
     'run_shell_command_jupyter',
@@ -5,16 +8,25 @@ __all__ = [
 ]
 
 
+from davos.exceptions import ParserNotImplementedError
+
+
 def register_smuggler_jupyter():
-    raise NotImplementedError("davos does not currently support Jupyter notebooks")
+    raise ParserNotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )
 
 
 def run_shell_command_jupyter(command):
-    raise NotImplementedError("davos does not currently support Jupyter notebooks")
+    raise ParserNotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )
 
 
 def smuggle_jupyter():
-    raise NotImplementedError("davos does not currently support Jupyter notebooks")
+    raise NotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )
 
 
 smuggle_jupyter._register_smuggler = register_smuggler_jupyter

--- a/davos/jupyter.py
+++ b/davos/jupyter.py
@@ -3,6 +3,7 @@
 
 __all__ = [
     'activate_parser_jupyter',
+    'check_parser_active_jupyter',
     'deactivate_parser_jupyter',
     'run_shell_command_jupyter',
     'smuggle_jupyter',
@@ -14,6 +15,12 @@ from davos.exceptions import ParserNotImplementedError
 
 
 def activate_parser_jupyter():
+    raise NotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )
+
+
+def check_parser_active_jupyter():
     raise NotImplementedError(
         "davos does not currently support Jupyter notebooks"
     )

--- a/davos/jupyter.py
+++ b/davos/jupyter.py
@@ -1,18 +1,26 @@
-# TODO: add module docstring
+# ADD DOCSTRING
 
 
 __all__ = [
-    'register_smuggler_jupyter',
+    'activate_parser_jupyter',
+    'deactivate_parser_jupyter',
     'run_shell_command_jupyter',
-    'smuggle_jupyter'
+    'smuggle_jupyter',
+    'smuggle_parser_jupyter'
 ]
 
 
 from davos.exceptions import ParserNotImplementedError
 
 
-def register_smuggler_jupyter():
-    raise ParserNotImplementedError(
+def activate_parser_jupyter():
+    raise NotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )
+
+
+def deactivate_parser_jupyter():
+    raise NotImplementedError(
         "davos does not currently support Jupyter notebooks"
     )
 
@@ -29,4 +37,7 @@ def smuggle_jupyter():
     )
 
 
-smuggle_jupyter._register_smuggler = register_smuggler_jupyter
+def smuggle_parser_jupyter(line):
+    raise ParserNotImplementedError(
+        "davos does not currently support Jupyter notebooks"
+    )

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -3,47 +3,6 @@ from argparse import Action, ArgumentError, ArgumentParser, SUPPRESS
 from davos.exceptions import OnionArgumentError
 
 
-class SubtractAction(Action):
-    # ADD DOCSTRING
-    def __init__(
-            self,
-            option_strings,
-            dest,
-            default=None,
-            required=False,
-            help=None
-    ):
-        # ADD DOCSTRING
-        super().__init__(option_strings=option_strings, dest=dest, nargs=0,
-                         default=default, required=required, help=help)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        curr_count = getattr(namespace, self.dest, 0)
-        setattr(namespace, self.dest, curr_count - 1)
-
-
-class EditableAction(Action):
-    # ADD DOCSTRING
-    def __init__(
-            self,
-            option_strings,
-            dest,
-            default=None,
-            metavar=None,
-            help=None
-    ):
-        # ADD DOCSTRING
-        # NOTE: `argparse.Action` subclass constructors must contain
-        #  `dest` as a positional arg, but `self.dest` will always be
-        #  `'editable'` for this particular class
-        super().__init__(option_strings, dest, default=default,
-                         metavar=metavar, help=help)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, 'editable', True)
-        setattr(namespace, 'spec', values)
-
-
 class OnionParser(ArgumentParser):
     # ADD DOCSTRING
     def parse_args(self, args, namespace=None):
@@ -68,6 +27,47 @@ class OnionParser(ArgumentParser):
     def error(self, message):
         # ADD DOCSTRING
         raise OnionArgumentError(msg=message, onion_txt=self._args)
+
+
+class EditableAction(Action):
+    # ADD DOCSTRING
+    def __init__(
+            self,
+            option_strings,
+            dest,
+            default=None,
+            metavar=None,
+            help=None
+    ):
+        # ADD DOCSTRING
+        # NOTE: `argparse.Action` subclass constructors must contain
+        #  `dest` as a positional arg, but `self.dest` will always be
+        #  `'editable'` for this particular class
+        super().__init__(option_strings, dest, default=default,
+                         metavar=metavar, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, 'editable', True)
+        setattr(namespace, 'spec', values)
+
+
+class SubtractAction(Action):
+    # ADD DOCSTRING
+    def __init__(
+            self,
+            option_strings,
+            dest,
+            default=None,
+            required=False,
+            help=None
+    ):
+        # ADD DOCSTRING
+        super().__init__(option_strings=option_strings, dest=dest, nargs=0,
+                         default=default, required=required, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        curr_count = getattr(namespace, self.dest, 0)
+        setattr(namespace, self.dest, curr_count - 1)
 
 
 # does not include usage for `pip install [options] -r

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -1,4 +1,10 @@
-from argparse import Action, ArgumentError, ArgumentParser, SUPPRESS
+from argparse import (
+    Action,
+    ArgumentError,
+    ArgumentTypeError,
+    ArgumentParser,
+    SUPPRESS
+)
 
 from davos.exceptions import OnionArgumentError
 
@@ -15,6 +21,8 @@ class OnionParser(ArgumentParser):
                 raise OnionArgumentError(msg=e.message,
                                          argument=e.argument_name,
                                          onion_txt=self._args) from e
+            except ArgumentTypeError as e:
+                raise OnionArgumentError(msg=e.args[0], onion_txt=self._args)
             else:
                 if extras:
                     msg = f"Unrecognized arguments: {' '.join(extras)}"

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -1,9 +1,9 @@
-import argparse
+from argparse import Action, ArgumentParser, SUPPRESS
 
 from davos.exceptions import OnionArgumentError
 
 
-class SubtractAction(argparse.Action):
+class SubtractAction(Action):
     # ADD DOCSTRING
     def __init__(
             self,
@@ -22,7 +22,7 @@ class SubtractAction(argparse.Action):
         setattr(namespace, self.dest, curr_count - 1)
 
 
-class EditableAction(argparse.Action):
+class EditableAction(Action):
     # ADD DOCSTRING
     def __init__(
             self,
@@ -44,17 +44,11 @@ class EditableAction(argparse.Action):
         setattr(namespace, 'spec', values)
 
 
-class OnionParser(argparse.ArgumentParser):
+class OnionParser(ArgumentParser):
     # ADD DOCSTRING
     def error(self, message):
         # ADD DOCSTRING
         raise OnionArgumentError(message)
-
-    # def parse_args(self, args=None, namespace=None):
-    #     ns = super().parse_args(args=args, namespace=namespace)
-    #     args_dict = vars(ns)
-    #     n_quiet = args_dict.pop('quiet', 0)
-
 
 
 # does not include usage for `pip install [options] -r
@@ -69,7 +63,7 @@ pip install [options] <archive url/path> ...
 
 pip_parser = OnionParser(usage=_pip_install_usage,
                          add_help=False,
-                         argument_default=argparse.SUPPRESS)
+                         argument_default=SUPPRESS)
 
 
 # ======== Install Options ========
@@ -101,7 +95,7 @@ pip_install_opts.add_argument(
 )
 
 spec_or_editable = pip_install_opts.add_mutually_exclusive_group(required=True)
-spec_or_editable.add_argument('spec', nargs='?', help=argparse.SUPPRESS)
+spec_or_editable.add_argument('spec', nargs='?', help=SUPPRESS)
 spec_or_editable.add_argument(
     '-e',
     '--editable',
@@ -233,7 +227,7 @@ pep_517_subgroup.add_argument(
 pep_517_subgroup.add_argument(
     '--no-use-pep517',
     action='store_true',
-    help=argparse.SUPPRESS
+    help=SUPPRESS
 )
 
 pip_install_opts.add_argument(
@@ -384,7 +378,7 @@ pip_general_opts.add_argument(
 pip_general_opts.add_argument(
     '-q',
     '--quiet',
-    action='count',
+    action=SubtractAction,
     dest='verbosity',
     help="Give less output. Option is additive, and can be used up to 3 times "
          "(corresponding to WARNING, ERROR, and CRITICAL logging levels)."

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -1,9 +1,28 @@
-from argparse import Action, ArgumentParser, SUPPRESS
+import argparse
 
 from davos.exceptions import OnionArgumentError
 
 
-class EditableAction(Action):
+class SubtractAction(argparse.Action):
+    # ADD DOCSTRING
+    def __init__(
+            self,
+            option_strings,
+            dest,
+            default=None,
+            required=False,
+            help=None
+    ):
+        # ADD DOCSTRING
+        super().__init__(option_strings=option_strings, dest=dest, nargs=0,
+                         default=default, required=required, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        curr_count = getattr(namespace, self.dest, 0)
+        setattr(namespace, self.dest, curr_count - 1)
+
+
+class EditableAction(argparse.Action):
     # ADD DOCSTRING
     def __init__(
             self,
@@ -25,11 +44,17 @@ class EditableAction(Action):
         setattr(namespace, 'spec', values)
 
 
-class OnionParser(ArgumentParser):
+class OnionParser(argparse.ArgumentParser):
     # ADD DOCSTRING
     def error(self, message):
         # ADD DOCSTRING
         raise OnionArgumentError(message)
+
+    # def parse_args(self, args=None, namespace=None):
+    #     ns = super().parse_args(args=args, namespace=namespace)
+    #     args_dict = vars(ns)
+    #     n_quiet = args_dict.pop('quiet', 0)
+
 
 
 # does not include usage for `pip install [options] -r
@@ -44,7 +69,7 @@ pip install [options] <archive url/path> ...
 
 pip_parser = OnionParser(usage=_pip_install_usage,
                          add_help=False,
-                         argument_default=SUPPRESS)
+                         argument_default=argparse.SUPPRESS)
 
 
 # ======== Install Options ========
@@ -76,7 +101,7 @@ pip_install_opts.add_argument(
 )
 
 spec_or_editable = pip_install_opts.add_mutually_exclusive_group(required=True)
-spec_or_editable.add_argument('spec', nargs='?', help=SUPPRESS)
+spec_or_editable.add_argument('spec', nargs='?', help=argparse.SUPPRESS)
 spec_or_editable.add_argument(
     '-e',
     '--editable',
@@ -208,7 +233,7 @@ pep_517_subgroup.add_argument(
 pep_517_subgroup.add_argument(
     '--no-use-pep517',
     action='store_true',
-    help=SUPPRESS
+    help=argparse.SUPPRESS
 )
 
 pip_install_opts.add_argument(
@@ -353,12 +378,14 @@ pip_general_opts.add_argument(
     '-v',
     '--verbose',
     action='count',
+    dest='verbosity',
     help="Give more output. Option is additive, and can be used up to 3 times."
 )
 pip_general_opts.add_argument(
     '-q',
     '--quiet',
     action='count',
+    dest='verbosity',
     help="Give less output. Option is additive, and can be used up to 3 times "
          "(corresponding to WARNING, ERROR, and CRITICAL logging levels)."
 )

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -1,0 +1,426 @@
+from argparse import ArgumentParser, SUPPRESS
+
+
+# does not include usage for `pip install [options] -r
+# <requirements file> [package-index-options] ...` since it's not
+# relevant to `davos` usage
+_pip_install_usage = '\n  '.join("""
+pip install [options] <requirement specifier> [package-index-options] ...
+pip install [options] [-e] <vcs project url> ...
+pip install [options] [-e] <local project path> ...
+pip install [options] <archive url/path> ...
+""".splitlines())
+
+
+pip_parser = ArgumentParser(usage=_pip_install_usage, allow_abbrev=False, exit_on_error=False, )
+
+
+# ======== Install Options ========
+pip_install_opts = pip_parser.add_argument_group(title="Install Options")
+# pip_install_opts.add_argument('-r', '--requirement', metavar='<file>', help="Install from the given requirements file. This option can be used multiple times.")
+# pip_install_opts.add_argument('-c', '--constraint', metavar='<file>', help="Constrain versions using the given constraints file. This option can be used multiple times.")
+pip_install_opts.add_argument(
+    '--no-deps',
+    action='store_true',
+    help="Don't install package dependencies."
+)
+pip_install_opts.add_argument(
+    '--pre',
+    action='store_true',
+    help="Include pre-release and development versions. By default, pip only "
+         "finds stable versions."
+)
+pip_install_opts.add_argument(
+    '-e',
+    '--editable',
+    metavar='<path/url>',
+    help='Install a project in editable mode (i.e. setuptools "develop mode") '
+         'from a local project path or a VCS url.'
+)
+pip_install_opts.add_argument(
+    '-t',
+    '--target',
+    metavar='<dir>',
+    help="Install packages into <dir>. By default this will not replace "
+         "existing files/folders in <dir>. Use --upgrade to replace existing "
+         "packages in <dir> with new versions."
+)
+pip_install_opts.add_argument(
+    '--platform',
+    metavar='<platform>',
+    help="Only use wheels compatible with <platform>. Defaults to the "
+         "platform of the running system. Use this option multiple times to "
+         "specify multiple platforms supported by the target interpreter."
+)
+pip_install_opts.add_argument(
+    '--python-version',
+    metavar='<python_version>',
+    help='The Python interpreter version to use for wheel and '
+         '"Requires-Python" compatibility checks. Defaults to a version '
+         'derived from the running interpreter. The version can be specified '
+         'using up to three dot-separated integers (e.g. "3" for 3.0.0, "3.7" '
+         'for 3.7.0, or "3.7.3"). A major-minor version can also be given as '
+         'a string without dots (e.g. "37" for 3.7.0).'
+)
+pip_install_opts.add_argument(
+    '--implementation',
+    metavar='<implementation>',
+    help="Only use wheels compatible with Python implementation "
+         "<implementation>, e.g. 'pp', 'jy', 'cp', or 'ip'. If not specified, "
+         "then the current interpreter implementation is used. Use 'py' to "
+         "force implementation-agnostic wheels."
+)
+pip_install_opts.add_argument(
+    '--abi',
+    metavar='<abi>',
+    help="Only use wheels compatible with Python abi <abi>, e.g. 'pypy_41'. "
+         "If not specified, then the current interpreter abi tag is used. Use "
+         "this option multiple times to specify multiple abis supported by "
+         "the target interpreter. Generally you will need to specify "
+         "--implementation, --platform, and --python-version when using this "
+         "option."
+)
+pip_install_opts.add_argument(
+    '--user',
+    action='store_true',
+    help="Install to the Python user install directory for your platform. "
+         "Typically ~/.local/, or %APPDATA%Python on Windows. (See the Python "
+         "documentation for site.USER_BASE for full details.)"
+)
+pip_install_opts.add_argument(
+    '--root',
+    metavar='<dir>',
+    help="Install everything relative to this alternate root directory."
+)
+pip_install_opts.add_argument(
+    '--prefix',
+    metavar='<dir>',
+    help="Installation prefix where lib, bin and other top-level folders are "
+         "placed"
+)
+pip_install_opts.add_argument(
+    '--src',
+    metavar='<dir>',
+    help='Directory to check out editable projects into. The default in a '
+         'virtualenv is "<venv path>/src". The default for global installs is '
+         '"<current dir>/src".'
+)
+pip_install_opts.add_argument(
+    '-U',
+    '--upgrade',
+    action='store_true',
+    help="Upgrade all specified packages to the newest available version. The "
+         "handling of dependencies depends on the upgrade-strategy used."
+)
+pip_install_opts.add_argument(
+    '--upgrade-strategy',
+    metavar='<upgrade_strategy>',
+    help='Determines how dependency upgrading should be handled [default: '
+         'only-if-needed]. "eager" - dependencies are upgraded regardless of '
+         'whether the currently installed version satisfies the requirements '
+         'of the upgraded package(s). "only-if-needed" - are upgraded only '
+         'when they do not satisfy the requirements of the upgraded '
+         'package(s).'
+)
+pip_install_opts.add_argument(
+    '--force-reinstall',
+    action='store_true',
+    help="Reinstall all packages even if they are already up-to-date."
+)
+pip_install_opts.add_argument(
+    '-I',
+    '--ignore-installed',
+    action='store_true',
+    help="Ignore the installed packages, overwriting them. This can break "
+         "your system if the existing package is of a different version or "
+         "was installed with a different package manager!"
+)
+pip_install_opts.add_argument(
+    '--ignore-requires-python',
+    action='store_true',
+    help="Ignore the Requires-Python information."
+)
+pip_install_opts.add_argument(
+    '--no-build-isolation',
+    action='store_true',
+    help="Disable isolation when building a modern source distribution. Build "
+         "dependencies specified by PEP 518 must be already installed if this "
+         "option is used."
+)
+
+pep_517_subgroup = pip_install_opts.add_mutually_exclusive_group()
+pep_517_subgroup.add_argument(
+    '--use-pep517',
+    action='store_true',
+    dest='use_pep517',
+    help="Use PEP 517 for building source distributions (use --no-use-pep517 "
+         "to force legacy behaviour)."
+)
+pep_517_subgroup.add_argument(
+    '--no-use-pep517',
+    action='store_true',
+    dest='use_pep517',
+    help=SUPPRESS
+)
+pep_517_subgroup.set_defaults(use_pep517=True)
+
+pip_install_opts.add_argument(
+    '--install-option',
+    action='append',
+    default=[],
+    metavar='<options>',
+    help='Extra arguments to be supplied to the setup.py install command (use '
+         'like --install-option="--install-scripts=/usr/local/bin"). Use '
+         'multiple --install-option options to pass multiple options to '
+         'setup.py install. If you are using an option with a directory path, '
+         'be sure to use absolute path.'
+)
+pip_install_opts.add_argument(
+    '--global-option',
+    action='append',
+    default=[],
+    metavar='<options>',
+    help="Extra global options to be supplied to the setup.py call before the "
+         "install command."
+)
+
+compile_subgroup = pip_install_opts.add_mutually_exclusive_group()
+compile_subgroup.add_argument(
+    '--compile',
+    action='store_true',
+    dest='compile',
+    help="Compile Python source files to bytecode"
+)
+compile_subgroup.add_argument(
+    '--no-compile',
+    action='store_false',
+    dest='compile',
+    help="Do not compile Python source files to bytecode"
+)
+compile_subgroup.set_defaults(compile=False)
+
+pip_install_opts.add_argument(
+    '--no-warn-script-location',
+    action='store_true',
+    help="Do not warn when installing scripts outside PATH"
+)
+pip_install_opts.add_argument(
+    '--no-warn-conflicts',
+    action='store_true',
+    help="Do not warn about broken dependencies"
+)
+# NOTE: in the actual pip-install implementation, `--no-binary`,
+#  `--only-binary`, and `--prefer-binary` triggers a fairly complex
+#  callback. But fortunately, we can just store all invocations and
+#  forward them to the real pip-install parser
+pip_install_opts.add_argument(
+    '--no-binary',
+    action='append',
+    default=[],
+    metavar='<format_control>',
+    help='Do not use binary packages. Can be supplied multiple times, and '
+         'each time adds to the existing value. Accepts either ":all:" to '
+         'disable all binary packages, ":none:" to empty the set (notice the '
+         'colons), or one or more package names with commas between them (no '
+         'colons). Note that some packages are tricky to compile and may fail '
+         'to install when this option is used on them.'
+)
+pip_install_opts.add_argument(
+    '--only-binary',
+    action='append',
+    default=[],
+    metavar='<format_control>',
+    help='Do not use source packages. Can be supplied multiple times, and '
+         'each time adds to the existing value. Accepts either ":all:" to '
+         'disable all source packages, ":none:" to empty the set, or one or '
+         'more package names with commas between them. Packages without '
+         'binary distributions will fail to install when this option is used '
+         'on them.'
+)
+pip_install_opts.add_argument(
+    '--prefer-binary',
+    action='store_true',
+    help="Prefer older binary packages over newer source packages."
+)
+pip_install_opts.add_argument(
+    '--require-hashes',
+    action='store_true',
+    help="Require a hash to check each requirement against, for repeatable "
+         "installs. This option is implied when any package in a requirements "
+         "file has a --hash option."
+)
+pip_install_opts.add_argument(
+    '--progress-bar',
+    default='on',
+    choices=('off', 'on', 'ascii', 'pretty', 'emoji'),
+    metavar='<progress_bar>',
+    help="Specify type of progress to be displayed "
+         "[off|on|ascii|pretty|emoji] (default: on)"
+)
+pip_install_opts.add_argument(
+    '--no-clean',
+    action='store_true',
+    help="Don’t clean up build directories."
+)
+
+
+# ======== Package Index Options ========
+pip_index_opts = pip_parser.add_argument_group(title="Package Index Options")
+pip_index_opts.add_argument(
+    '-i',
+    '--index-url',
+    metavar='<url>',
+    help="Base URL of the Python Package Index (default "
+         "https://pypi.org/simple). This should point to a repository "
+         "compliant with PEP 503 (the simple repository API) or a local "
+         "directory laid out in the same format."
+)
+pip_index_opts.add_argument(
+    '--extra-index-url',
+    action='append',
+    default=[],
+    metavar='<url>',
+    help="Extra URLs of package indexes to use in addition to --index-url. "
+         "Should follow the same rules as --index-url."
+)
+pip_index_opts.add_argument(
+    '--no-index',
+    action='store_true',
+    help="Ignore package index (only looking at --find-links URLs instead)."
+)
+pip_index_opts.add_argument(
+    '-f',
+    '--find-links',
+    action='append',
+    metavar='<url>',
+    help="If a URL or path to an html file, then parse for links to archives "
+         "such as sdist (.tar.gz) or wheel (.whl) files. If a local path or "
+         "file:// URL that’s a directory, then look for archives in the "
+         "directory listing. Links to VCS project URLs are not supported."
+)
+
+
+# ======== general arguments ========
+pip_general_opts = pip_parser.add_argument_group(title='General Options')
+pip_general_opts.add_argument(
+    '--isolated',
+    action='store_true',
+    help="Run pip in an isolated mode, ignoring environment variables and "
+         "user configuration."
+)
+# verbose and quiet should theoretically be mutally exclusive, but pip
+# itself doesn't seem to implement them as such, so not worth doing so
+# here
+pip_general_opts.add_argument(
+    '-v',
+    '--verbose',
+    action='count',
+    default=0,
+    help="Give more output. Option is additive, and can be used up to 3 times."
+)
+pip_general_opts.add_argument(
+    '-q',
+    '--quiet',
+    action='count',
+    default=0,
+    help="Give less output. Option is additive, and can be used up to 3 times "
+         "(corresponding to WARNING, ERROR, and CRITICAL logging levels)."
+)
+pip_general_opts.add_argument(
+    '--log',
+    metavar='<path>',
+    help="Path to a verbose appending log."
+)
+pip_general_opts.add_argument(
+    '--retries',
+    type=int,
+    default=5,
+    metavar='<retries>',
+    help="Maximum number of retries each connection should attempt (default 5 "
+         "times)."
+)
+pip_general_opts.add_argument(
+    '--timeout',
+    type=float,
+    default=15,
+    metavar='<sec>',
+    help="Set the socket timeout (default 15 seconds)."
+)
+pip_general_opts.add_argument(
+    '--exists-action',
+    default=None,
+    choices=(
+        's',
+        'switch',
+        'i',
+        'ignore',
+        'w',
+        'wipe',
+        'b',
+        'backup',
+        'a',
+        'abort'
+    ),
+    metavar='<action>',
+    help="Default action when a path already exists: (s)witch, (i)gnore, "
+         "(w)ipe, (b)ackup, (a)bort."
+)
+pip_general_opts.add_argument(
+    '--trusted-host',
+    metavar='<hostname>',
+    help="Mark this host or host:port pair as trusted, even though it does "
+         "not have valid or any HTTPS."
+)
+pip_general_opts.add_argument(
+    '--cert',
+    metavar='<path>',
+    help="Path to alternate CA bundle."
+)
+pip_general_opts.add_argument(
+    '--client-cert',
+    metavar='<path>',
+    help="Path to SSL client certificate, a single file containing the "
+         "private key and the certificate in PEM format."
+)
+
+cache_dir_subgroup = pip_general_opts.add_mutually_exclusive_group()
+cache_dir_subgroup.add_argument(
+    '--cache-dir',
+    metavar='<dir>',
+    help="Store the cache data in <dir>."
+)
+cache_dir_subgroup.add_argument(
+    '--no-cache-dir',
+    action='store_true',
+    help="Disable the cache."
+)
+
+pip_general_opts.add_argument(
+    '--disable-pip-version-check',
+    action='store_true',
+    help="Don't periodically check PyPI to determine whether a new version of "
+         "pip is available for download. Implied with --no-index."
+)
+# NOTE: I think this would have no effect in Jupyter/Colab environments
+pip_general_opts.add_argument(
+    '--no-color',
+    action='store_true',
+    help="uppress colored output."
+)
+pip_general_opts.add_argument(
+    '--no-python-version-warning',
+    action='store_true',
+    help="Silence deprecation warnings for upcoming unsupported Pythons."
+)
+pip_general_opts.add_argument(
+    '--use-feature',
+    action='store_true',
+    metavar='<feature>',
+    help="Enable new functionality, that may be backward incompatible."
+)
+pip_general_opts.add_argument(
+    '--use-deprecated',
+    action='store_true',
+    metavar='<feature>',
+    help="Enable deprecated functionality, that will be removed in the future."
+)

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -31,10 +31,6 @@ class OnionParser(ArgumentParser):
         # ADD DOCSTRING
         raise OnionArgumentError(message)
 
-    def parse_args(self, args=None, namespace=None):
-        ns = super().parse_args(args=args, namespace=namespace)
-        args_dict = vars(ns)
-
 
 # does not include usage for `pip install [options] -r
 # <requirements file> [package-index-options] ...` since it's not

--- a/davos/parsers.py
+++ b/davos/parsers.py
@@ -21,7 +21,7 @@ class OnionParser(ArgumentParser):
                 raise OnionArgumentError(msg=e.message,
                                          argument=e.argument_name,
                                          onion_txt=self._args) from e
-            except ArgumentTypeError as e:
+            except (ArgumentTypeError, ValueError) as e:
                 raise OnionArgumentError(msg=e.args[0], onion_txt=self._args)
             else:
                 if extras:

--- a/davos/python.py
+++ b/davos/python.py
@@ -1,3 +1,6 @@
+# TODO: add module docstring
+
+
 __all__ = [
     'register_smuggler_python',
     'run_shell_command_python',
@@ -11,10 +14,13 @@ import sys
 from subprocess import CalledProcessError, PIPE, Popen
 
 from davos import davos
+from davos.exceptions import ParserNotImplementedError
 
 
 def register_smuggler_python():
-    raise NotImplementedError("davos does not currently support pure Python interpreters")
+    raise ParserNotImplementedError(
+        "davos does not currently support pure Python interpreters"
+    )
 
 
 def run_shell_command_python(command):
@@ -40,7 +46,9 @@ def run_shell_command_python(command):
 
 
 def smuggle_python():
-    raise NotImplementedError("davos does not currently support pure Python interpreters")
+    raise NotImplementedError(
+        "davos does not currently support pure Python interpreters"
+    )
 
 
 smuggle_python._register_smuggler = register_smuggler_python

--- a/davos/python.py
+++ b/davos/python.py
@@ -3,6 +3,7 @@
 
 __all__ = [
     'activate_parser_python',
+    'check_parser_active_python',
     'deactivate_parser_python',
     'run_shell_command_python',
     'smuggle_python',
@@ -18,6 +19,12 @@ from subprocess import CalledProcessError, PIPE, Popen
 
 
 def activate_parser_python():
+    raise NotImplementedError(
+        "davos does not currently support pure Python interpreters"
+    )
+
+
+def check_parser_active_python():
     raise NotImplementedError(
         "davos does not currently support pure Python interpreters"
     )

--- a/davos/python.py
+++ b/davos/python.py
@@ -1,11 +1,14 @@
-# TODO: add module docstring
+# ADD DOCSTRING
 
 
 __all__ = [
-    'register_smuggler_python',
+    'activate_parser_python',
+    'deactivate_parser_python',
     'run_shell_command_python',
-    'smuggle_python'
+    'smuggle_python',
+    'smuggle_parser_python'
 ]
+
 
 import locale
 import shlex
@@ -13,17 +16,21 @@ import signal
 import sys
 from subprocess import CalledProcessError, PIPE, Popen
 
-from davos import davos
-from davos.exceptions import ParserNotImplementedError
+
+def activate_parser_python():
+    raise NotImplementedError(
+        "davos does not currently support pure Python interpreters"
+    )
 
 
-def register_smuggler_python():
-    raise ParserNotImplementedError(
+def deactivate_parser_python():
+    raise NotImplementedError(
         "davos does not currently support pure Python interpreters"
     )
 
 
 def run_shell_command_python(command):
+    # ADD DOCSTRING
     cmd = shlex.split(command)
     process = Popen(cmd, stdout=PIPE, stderr=PIPE,
                     encoding=locale.getpreferredencoding())
@@ -51,4 +58,7 @@ def smuggle_python():
     )
 
 
-smuggle_python._register_smuggler = register_smuggler_python
+def smuggle_parser_python(script_text):
+    raise NotImplementedError(
+        "davos does not currently support pure Python interpreters"
+    )

--- a/tests/test_davos_colab.ipynb
+++ b/tests/test_davos_colab.ipynb
@@ -1,0 +1,1788 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "test-davos-colab.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "J2ClQflyITTI"
+      },
+      "source": [
+        "<p align=\"center\"\n",
+        "    <a href=\"https://colab.research.google.com/github/ContextLab/psyc32-hello-world/blob/master/hello_world_assignment.ipynb\" target=\"_parent\">\n",
+        "        <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\">\n",
+        "    </a>\n",
+        "</p>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sXPlvCvRsuLE"
+      },
+      "source": [
+        "import ast\n",
+        "import contextlib\n",
+        "import functools\n",
+        "import os\n",
+        "import signal\n",
+        "import subprocess\n",
+        "import sys\n",
+        "import types\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import pkg_resources\n",
+        "from IPython.core.ultratb import AutoFormattedTB"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "73wNblHUaT8s"
+      },
+      "source": [
+        "# **Test helpers**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dSVO_4asVNe6"
+      },
+      "source": [
+        "setup_funcs = []\n",
+        "tests = []"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ufPkHItMyqB4"
+      },
+      "source": [
+        "class DavosTestingError:\n",
+        "    \"\"\"Base class for Davos testing-related errors\"\"\"\n",
+        "    pass\n",
+        "\n",
+        "\n",
+        "class DavosAssertionError(DavosTestingError, AssertionError):\n",
+        "    \"\"\"Subclasses AssertionError for pytest-specific handling\"\"\"\n",
+        "    pass\n",
+        "\n",
+        "\n",
+        "class TestingEnvironmentError(DavosAssertionError, OSError):\n",
+        "    \"\"\"Raised due to issues with the testing environment\"\"\"\n",
+        "    pass\n",
+        "\n",
+        "\n",
+        "class NonColabEnvironmentError(TestingEnvironmentError):\n",
+        "    \"\"\"Raised if this notebook is run outside of Colaboratory\"\"\"\n",
+        "    def __init__(self, *args):\n",
+        "        msg = \"Tests in this notebook are meant to be run in a Colaboratory environment\"\n",
+        "        super().__init__(msg, *args)\n",
+        "\n",
+        "\n",
+        "class TestTimeoutError(DavosAssertionError):\n",
+        "    \"\"\"Raised if a test exceeds its timeout limit\"\"\"\n",
+        "    pass"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1X6xLIDjLvH8"
+      },
+      "source": [
+        "def _expected_onion_parser_output(args_str, **installer_kwargs):\n",
+        "    _installer_kwargs = {'editable': False, 'spec': args_str}\n",
+        "    _installer_kwargs.update(installer_kwargs)\n",
+        "    return '\"pip\"', f'\"\"\"{args_str}\"\"\"', _installer_kwargs"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "aC6WMKyNxtSl"
+      },
+      "source": [
+        "def _expected_parser_output(name, as_=None, args_str=None, **installer_kwargs):\n",
+        "    if as_ is not None:\n",
+        "        as_ = f'\"{as_}\"'\n",
+        "    expected = f'smuggle(name=\"{name}\", as_={as_}'\n",
+        "    if args_str is not None or any(installer_kwargs):\n",
+        "        installer, args_str, inst_kwargs = _expected_onion_parser_output(args_str, **installer_kwargs)\n",
+        "        expected += f', installer={installer}, args_str={args_str}, installer_kwargs={inst_kwargs}'\n",
+        "    return expected + ')'"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "lTOnvuyrM487"
+      },
+      "source": [
+        "def _is_imported(package):\n",
+        "    if package in sys.modules:\n",
+        "        return True\n",
+        "    elif any(pkg.startswith(f'{package}.') for pkg in sys.modules):\n",
+        "        return True\n",
+        "    return False"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9Alh4UZEP2Ac"
+      },
+      "source": [
+        "def _is_installed(package):\n",
+        "    try:\n",
+        "        dist = pkg_resources.get_distribution(package)\n",
+        "    except pkg_resources.DistributionNotFound:\n",
+        "        return False\n",
+        "    else:\n",
+        "        return True"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "LuXE3Dvny_wo"
+      },
+      "source": [
+        "def _matches_expected_output(expected, result):\n",
+        "    all_match = True\n",
+        "    expected_chunks = expected.split(';')\n",
+        "    result_chunks = result.split(';')\n",
+        "    assert len(expected_chunks) == len(result_chunks)\n",
+        "    for expected_chunk, result_chunk in zip(expected_chunks, result_chunks):\n",
+        "        if 'installer_kwargs=' in expected_chunk and 'installer_kwargs' in result_chunk:\n",
+        "            exp_main, exp_kwargs = expected_chunk.strip().split('installer_kwargs=')\n",
+        "            res_main, res_kwargs = result_chunk.strip().split('installer_kwargs=')\n",
+        "            # remove ')'\n",
+        "            exp_kwargs = ast.literal_eval(exp_kwargs[:-1])\n",
+        "            res_kwargs = ast.literal_eval(res_kwargs[:-1])\n",
+        "            all_match = all_match and exp_main == res_main and exp_kwargs == res_kwargs\n",
+        "        else:\n",
+        "            all_match = all_match and expected_chunk == result_chunk\n",
+        "    return all_match"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1CeVqSKle5zT"
+      },
+      "source": [
+        "def _parse_line(line):\n",
+        "    return davos.colab.smuggle_parser_colab(line)"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pHqLqdn0e51X"
+      },
+      "source": [
+        "def _parse_onion(onion):\n",
+        "    return davos.core.Onion.parse_onion(onion)"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "J6F_6mB6VAOI"
+      },
+      "source": [
+        "def setup_func(func):\n",
+        "    @functools.wraps(func)\n",
+        "    def _wrapped():\n",
+        "        return func()\n",
+        "        \n",
+        "    setup_funcs.append(func)\n",
+        "    return _wrapped"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pbaCKBNeVAjR"
+      },
+      "source": [
+        "def test(func=None, *, timeout=100):\n",
+        "    def decorator(func):\n",
+        "        def handler(signum, frame):\n",
+        "            raise TestTimeoutError(\n",
+        "                f\"'{func.__name__}' timed out after {timeout} seconds\"\n",
+        "            )\n",
+        "        @functools.wraps(func)\n",
+        "        def wrapper():\n",
+        "            # print(f'timeout is {timeout}')\n",
+        "            signal.signal(signal.SIGALRM, handler)\n",
+        "            signal.alarm(timeout)\n",
+        "            try:\n",
+        "                return func()\n",
+        "            finally:\n",
+        "                signal.alarm(0)\n",
+        "\n",
+        "        tests.append(wrapper)\n",
+        "        return wrapper\n",
+        "    \n",
+        "    if func is not None:\n",
+        "        return decorator(func)\n",
+        "    return decorator"
+      ],
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "eujmFjaFWwVm"
+      },
+      "source": [
+        "def run_setup(source='github', ref=None, fork=None):\n",
+        "    n_funcs = len(setup_funcs)\n",
+        "    for i, sf in enumerate(setup_funcs):\n",
+        "        name = sf.__name__\n",
+        "        prefix = f\"{i+1}/{n_funcs} {name}:\"\n",
+        "        print(f\"{prefix}{' '*(60-len(prefix))}\", end='')\n",
+        "        try:\n",
+        "            if name == 'test_install_davos':\n",
+        "                sf(source=source, ref=ref, fork=fork)\n",
+        "            else:\n",
+        "                sf()\n",
+        "        except:\n",
+        "            print('failed')\n",
+        "            raise\n",
+        "        else:\n",
+        "            print('passed')"
+      ],
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8TThnBUIy3h7"
+      },
+      "source": [
+        "def show_failures(names_excs):\n",
+        "    tb_displayer = AutoFormattedTB('Context', 'LightBG')\n",
+        "    for name, exc in names_excs:\n",
+        "        n_pre = (85 - len(name) - 2) // 2\n",
+        "        n_post = 85 - len(name) - 2 - n_pre\n",
+        "        print(f\"{'='*n_pre} {name} {'='*n_post}\")\n",
+        "        print(tb_displayer.text(type(exc), exc, exc.__traceback__))\n",
+        "        print('\\n\\n\\n')"
+      ],
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "LRdPqhZ0WwX4"
+      },
+      "source": [
+        "def run_tests(live_stdout=False):\n",
+        "    if live_stdout:\n",
+        "        stdout_context = contextlib.nullcontext\n",
+        "    else:\n",
+        "        stdout_context = contextlib.redirect_stdout\n",
+        "    names_excs = []\n",
+        "    n_tests = len(tests)\n",
+        "    for i, tf in enumerate(tests, start=1):\n",
+        "        name = tf.__name__\n",
+        "        prefix = f\"{i}/{n_tests}{' ' if i > 9 else '  '}{name}:\"\n",
+        "        print(f\"{prefix}{' '*(85-len(prefix))}\", end='')\n",
+        "        try:\n",
+        "            with open(os.devnull, 'w') as devnull, stdout_context(devnull):\n",
+        "                tf()\n",
+        "        except Exception as e:\n",
+        "            names_excs.append((name, e))\n",
+        "            if isinstance(e, TestTimeoutError):\n",
+        "                print('timed out')\n",
+        "            else:\n",
+        "                print('failed')\n",
+        "        else:\n",
+        "            print('passed')\n",
+        "    \n",
+        "    print('\\n\\n')\n",
+        "    n_failed = len(names_excs)\n",
+        "    if n_failed == 0:\n",
+        "        print('All tests passed!')\n",
+        "    else:\n",
+        "        print(f'{n_tests-n_failed}/{n_tests} passed')\n",
+        "        print('Displaying errors from failing tests:')\n",
+        "        print('\\n\\n')\n",
+        "    show_failures(names_excs)"
+      ],
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TTnx8Ux83ugP"
+      },
+      "source": [
+        "# **Setup tests**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Jamfm0pP4LpR"
+      },
+      "source": [
+        "### Testing environment validation & installation tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PuVsfmse6GQ8"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_import_ipython():\n",
+        "    global IPython\n",
+        "    try:\n",
+        "        import IPython\n",
+        "    except ModuleNotFoundError as e:\n",
+        "        raise NonColabEnvironmentError() from e"
+      ],
+      "execution_count": 16,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "J4V4sMqS4LBM"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_import_google():\n",
+        "    global google\n",
+        "    try:\n",
+        "        import google\n",
+        "    except ModuleNotFoundError as e:\n",
+        "        raise NonColabEnvironmentError() from e"
+      ],
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vimIIlfT5hdu"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_get_ipython_shell():\n",
+        "    global IPYTHON_SHELL\n",
+        "    try:\n",
+        "        IPYTHON_SHELL = get_ipython()\n",
+        "    except NameError as e:\n",
+        "        raise NonColabEnvironmentError() from e"
+      ],
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0aMa2x7n5-cg"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_ipython_shell_is_colab_shell():\n",
+        "    try:\n",
+        "        assert isinstance(IPYTHON_SHELL, google.colab._shell.Shell)\n",
+        "    except AssertionError as e:\n",
+        "        raise NonColabEnvironmentError() from e\n",
+        "    except AttributeError as e:\n",
+        "        google_version = pkg_resources.get_distribution('google').version\n",
+        "        raise TestingEnvironmentError(\n",
+        "            \"Qualified name for Colab shell class has changed (google module \"\n",
+        "            \"may have been recently updated).\\n\\tShell type:\\t\"\n",
+        "            f\"{type(IPYTHON_SHELL)}\\n\\tgoogle version:\\t{google_version}\"\n",
+        "        ) from e"
+      ],
+      "execution_count": 19,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Jq9BX8VC9XaZ"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_ipython_version():\n",
+        "    ipy_version = IPython.__version__\n",
+        "    try:\n",
+        "        assert ipy_version == '5.5.0'\n",
+        "    except AssertionError as e:\n",
+        "        raise TestingEnvironmentError(\n",
+        "            f\"Found unexpected IPython version: {ipy_version}\\nExpected \"\n",
+        "            \"IPython==5.5.0\"\n",
+        "        ) from e"
+      ],
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "nVW4u29OT4Uj"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_no_transforms_registered():\n",
+        "    assert len(IPYTHON_SHELL.input_splitter.python_line_transforms) == 0\n",
+        "    assert len(IPYTHON_SHELL.input_transformer_manager.python_line_transforms) == 0"
+      ],
+      "execution_count": 21,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "w_m4bwUBtI6S"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_install_davos(source='github', ref=None, fork=None):\n",
+        "    source = source.lower()\n",
+        "    if source == 'github':\n",
+        "        if fork is None:\n",
+        "            fork = 'ContextLab'\n",
+        "        name = f'git+https://github.com/{fork}/davos.git'\n",
+        "        if ref is not None:\n",
+        "            name += f'@{ref}'\n",
+        "        name += '#egg=davos'\n",
+        "    elif source in ('pip', 'pypi', 'testpypi'):\n",
+        "        name = 'davos'\n",
+        "        if source == 'testpypi':\n",
+        "            name = '--index-url https://test.pypi.org/simple/ ' + name\n",
+        "        if ref is not None:\n",
+        "            name += f'=={ref}'\n",
+        "    elif source == 'conda':\n",
+        "        raise NotImplementedError(\n",
+        "            \"conda installation is not supported in Colaboratory\"\n",
+        "        )\n",
+        "    else:\n",
+        "        raise ValueError(f\"Invalid source '{source}'\")\n",
+        "    \n",
+        "    return_code = IPython.core.interactiveshell.system(f'pip install {name}')\n",
+        "    if return_code != 0:\n",
+        "        raise DavosTestingError(\n",
+        "            f\"Failed to install 'davos'. Ran command:\\n\\t`pip install {name}`\"\n",
+        "            )"
+      ],
+      "execution_count": 22,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3akA2h2zSwI7"
+      },
+      "source": [
+        "### Import & initialization tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "t7rW8ymXKCI6"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_import_davos():\n",
+        "    global davos\n",
+        "    try:\n",
+        "        import davos\n",
+        "    except ModuleNotFoundError as e:\n",
+        "        raise DavosTestingError(\"Failed to import 'davos' after installation\")"
+      ],
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OeB54gfIU0pH"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_smuggler_transform_registered():\n",
+        "    splitter_transforms = IPYTHON_SHELL.input_splitter.python_line_transforms\n",
+        "    line_transforms = IPYTHON_SHELL.input_transformer_manager.python_line_transforms\n",
+        "    # transform be registered once (and only once) in both places\n",
+        "    assert len(splitter_transforms) == 1\n",
+        "    assert len(line_transforms) == 1\n",
+        "    smuggler_splitter_transform = splitter_transforms[0]\n",
+        "    smuggler_line_transform = line_transforms[0]\n",
+        "    # both should be StatelessInputTransformers that wrap the \n",
+        "    # `smuggle_parser_colab` function\n",
+        "    assert isinstance(smuggler_splitter_transform, \n",
+        "                      IPython.core.inputtransformer.StatelessInputTransformer)\n",
+        "    assert isinstance(smuggler_line_transform, \n",
+        "                      IPython.core.inputtransformer.StatelessInputTransformer)\n",
+        "    assert (smuggler_splitter_transform.func \n",
+        "            is smuggler_line_transform.func \n",
+        "            is davos.colab.smuggle_parser_colab)"
+      ],
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wjDdDkyHXft-"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_smuggle_function_in_namespace():\n",
+        "    assert 'smuggle' in IPYTHON_SHELL.user_ns"
+      ],
+      "execution_count": 25,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "954ebNTeYxUq"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_correct_functions_chosen():\n",
+        "    assert smuggle is davos.colab.smuggle_colab"
+      ],
+      "execution_count": 26,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "scwvd0G_aMsx"
+      },
+      "source": [
+        "@setup_func\n",
+        "def test_Davos_object_initialization():\n",
+        "    davos_obj = davos.davos\n",
+        "    assert davos_obj.confirm_install is False\n",
+        "    assert davos_obj.suppress_stdout is False\n",
+        "    assert davos_obj.smuggled == {}\n",
+        "    assert davos_obj.smuggler is davos.colab.smuggle_colab\n",
+        "    assert davos.activate is davos_obj.activate_parser is davos.colab.activate_parser_colab\n",
+        "    assert davos.deactivate is davos_obj.deactivate_parser is davos.colab.deactivate_parser_colab\n",
+        "    assert davos_obj._shell_cmd_helper is davos.colab.run_shell_command_colab\n",
+        "    assert davos_obj.parser_environment == 'IPY_OLD'"
+      ],
+      "execution_count": 27,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cTOksxgP3nSG"
+      },
+      "source": [
+        "# **Run setup tests**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "QMvGVihj4l-D",
+        "outputId": "8a7bc4a4-bd32-45f6-9f2a-866c35793a90"
+      },
+      "source": [
+        "run_setup(source='github', fork='paxtonfitzpatrick')"
+      ],
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1/12 test_import_ipython:                                   passed\n",
+            "2/12 test_import_google:                                    passed\n",
+            "3/12 test_get_ipython_shell:                                passed\n",
+            "4/12 test_ipython_shell_is_colab_shell:                     passed\n",
+            "5/12 test_ipython_version:                                  passed\n",
+            "6/12 test_no_transforms_registered:                         passed\n",
+            "7/12 test_install_davos:                                    Collecting davos\n",
+            "  Cloning https://github.com/paxtonfitzpatrick/davos.git to /tmp/pip-install-tgjr5kp0/davos\n",
+            "  Running command git clone -q https://github.com/paxtonfitzpatrick/davos.git /tmp/pip-install-tgjr5kp0/davos\n",
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+            "Building wheels for collected packages: davos\n",
+            "  Building wheel for davos (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for davos: filename=davos-0.0.1-cp37-none-any.whl size=27256 sha256=386b5cbd872b78a7d1112dca7f850c1e82c7eaf3caf0c4c645a3ec20b7accbe0\n",
+            "  Stored in directory: /tmp/pip-ephem-wheel-cache-5z6d2tok/wheels/6d/b5/22/60574bf4074226d4d9c357fbfe356cb75b8eda276caa67e403\n",
+            "Successfully built davos\n",
+            "Installing collected packages: davos\n",
+            "Successfully installed davos-0.0.1\n",
+            "passed\n",
+            "8/12 test_import_davos:                                     passed\n",
+            "9/12 test_smuggler_transform_registered:                    passed\n",
+            "10/12 test_smuggle_function_in_namespace:                   passed\n",
+            "11/12 test_correct_functions_chosen:                        passed\n",
+            "12/12 test_Davos_object_initialization:                     passed\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eeYkZiDL4Vrr"
+      },
+      "source": [
+        "# **Main tests**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h8zmDNgMgLGk"
+      },
+      "source": [
+        "## Unit tests"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AjpH754ElGt3"
+      },
+      "source": [
+        "### shell command runner tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oBF5TmvOhFSl"
+      },
+      "source": [
+        "@test\n",
+        "def test_run_shell_command_simple():\n",
+        "    stdout, retcode = davos.davos.run_shell_command('whoami', live_stdout=False)\n",
+        "    assert retcode == 0\n",
+        "    assert stdout == 'root\\r\\n'"
+      ],
+      "execution_count": 29,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MF0REQDfh5UF"
+      },
+      "source": [
+        "@test\n",
+        "def test_run_shell_command_multiword():\n",
+        "    quote = (\"Strictly speaking, I didn't do the theiving. That would be the \"\n",
+        "             \"pirates. I just moved what they stole from one place to another\")\n",
+        "    stdout, retcode = davos.davos.run_shell_command(f'echo \"{quote}\"', \n",
+        "                                                    live_stdout=False)\n",
+        "    assert retcode == 0\n",
+        "    assert stdout == quote + '\\r\\n'"
+      ],
+      "execution_count": 30,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "w7uenDGZcsuP"
+      },
+      "source": [
+        "@test\n",
+        "def test_run_shell_command_failure():\n",
+        "    try:\n",
+        "        davos.davos.run_shell_command('blahblahblah', live_stdout=True)\n",
+        "    except subprocess.CalledProcessError as e:\n",
+        "        assert e.returncode == 127\n",
+        "        assert e.output == '/bin/sh: 1: blahblahblah: not found\\r\\n', e.output.getvalue()"
+      ],
+      "execution_count": 31,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E4U8QOFolgpS"
+      },
+      "source": [
+        "### smuggle command parser tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VzF2OhxZkxnl"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_ignores_line_no_smuggle():\n",
+        "    line = \"def foo(bar, baz=qux):\"\n",
+        "    assert _parse_line(line) == line"
+      ],
+      "execution_count": 32,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-2e0f8r7mJNE"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_ignores_line_decoy_smuggle():\n",
+        "    \"\"\"a line that has \"smuggle\" in it, but should be ignored\"\"\"\n",
+        "    line = \"def smuggle_something(foo):\"\n",
+        "    assert _parse_line(line) == line"
+      ],
+      "execution_count": 33,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "i_8gCTv2mJQI"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_ignores_commented_line():\n",
+        "    \"\"\"parser should ignore commented-out smuggle statements\"\"\"\n",
+        "    line = \"# smuggle foo as bar\"\n",
+        "    assert _parse_line(line) == line"
+      ],
+      "execution_count": 34,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oUOlI4yEiaeW"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_basic_line():\n",
+        "    \"\"\"simplest use case\"\"\"\n",
+        "    line = \"smuggle foo\"\n",
+        "    expected = _expected_parser_output('foo')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 35,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "D4Vi1ay4ly4g"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_basic_line_alias():\n",
+        "    \"\"\"simplest use case, plus alias\"\"\"\n",
+        "    line = \"smuggle foo as bar\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 36,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QQqY5lFWia1U"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_basic_line_onion():\n",
+        "    \"\"\"simplest use case, with onion comment\"\"\"\n",
+        "    line = \"smuggle foo as bar    # pip: foo==0.0.1\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar', args_str='foo==0.0.1')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 37,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "f7laAO9UkU55"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_ignores_non_onion_comment():\n",
+        "    \"\"\"looks similar to the preivous one, but the inline comment is NOT an onion spec\"\"\"\n",
+        "    line = \"smuggle foo as bar    # omg foo is my FAVORITE package\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar') + \"    # omg foo is my FAVORITE package\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 38,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SDTuBZL9JGrs"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_ignores_imposter_onion_comment():\n",
+        "    \"\"\"VERY close to an onion comment, but doesn't start with \"pip:\" (note colon)\"\"\"\n",
+        "    line = \"smuggle foo as bar    # pip is a [redacted] package manager than conda\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar') + \"    # pip is a [redacted] package manager than conda\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 39,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8eUcnzCnrjH2"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_qualname():\n",
+        "    line = \"smuggle foo.bar as baz\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='baz')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 40,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "tYyTHhq6mJTB"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_indented_line():\n",
+        "    \"\"\"\n",
+        "    needs to handle, e.g.\n",
+        "        ```\n",
+        "        def foo():\n",
+        "            smuggle numpy as np\n",
+        "        ```\n",
+        "    Note: unless `davos.deactivate() is run, the above line will \n",
+        "    actually be parsed (though it will have no effect)\n",
+        "    \"\"\"\n",
+        "    line = \"    smuggle foo as bar\"\n",
+        "    expected = \"    \" + _expected_parser_output('foo', as_='bar')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 41,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vXFaqV8l4cba"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_different_install_name():\n",
+        "    \"\"\"\n",
+        "    sometimes, name used for pip-installation is different \n",
+        "    from name used to import\n",
+        "    \"\"\"\n",
+        "    line = \"smuggle foo as bar    # pip: foo-package==0.0.1\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar', \n",
+        "                                       args_str='foo-package==0.0.1')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 42,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bAXICxNor4a9"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_multiple_packages():\n",
+        "    line = \"smuggle foo as bar, baz as qux, spam, ham, eggs\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
+        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 43,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4Xm-d7dYhjuR"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_multiple_packages_onion():\n",
+        "    \"\"\"onion info should be passed to smuggle function for FIRST package\"\"\"\n",
+        "    line = \"smuggle foo as bar, baz as qux, spam, ham, eggs    # pip: foo==0.0.1\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
+        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 44,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UFRPxgIer4dc"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_backslash():\n",
+        "    line = \"\"\"smuggle foo as bar, \\\n",
+        "                      baz as qux, \\\n",
+        "                      spam, ham, \\\n",
+        "                      eggs\"\"\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
+        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 45,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wturHFrIr4fi"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_backslash_onion():\n",
+        "    \"\"\"again, onion info should be passed to smuggle function for FIRST package\"\"\"\n",
+        "    line = \"\"\"smuggle foo as bar, \\\n",
+        "                      baz as qux, \\\n",
+        "                      spam, ham, \\\n",
+        "                      eggs    # pip: foo==0.0.1\"\"\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
+        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 46,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wSFAB-8AgKi6"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_inconsistent_whitespace():\n",
+        "    \"\"\"should handle weird amounts of whitespace that are *technically* valid\"\"\"\n",
+        "    line = \"\"\"smuggle               foo as bar, \\\n",
+        "baz as qux, \\\n",
+        "                      spam,ham,eggs                        # pip:         foo==0.0.1    \"\"\"\n",
+        "    expected = _expected_parser_output('foo', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
+        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    # real parser adds back leading & trailing characters (including whitespace)\n",
+        "    expected += \"    \"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 47,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iiynLAjLgKnn"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from():\n",
+        "    \"\"\"second possible broad syntax class\"\"\"\n",
+        "    line = \"from foo smuggle bar\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 48,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8mPAq2AXsnS9"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_onion():\n",
+        "    \"\"\"second possible broad syntax class\"\"\"\n",
+        "    line = \"from foo smuggle bar    # pip: foo==0.0.1\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 49,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GGvdTMMgr3dp"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_multi():\n",
+        "    line = \"from foo smuggle bar, baz as spam, qux\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 50,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EjOyycpCQFm-"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_multi_onion():\n",
+        "    \"\"\"onion info should be passed to FIRST smuggle function\"\"\"\n",
+        "    line = \"from foo smuggle bar, baz as spam, qux    # pip: foo==0.0.1\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 51,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "grUaxSdCtXKQ"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_backslash():\n",
+        "    \"\"\"onion info should be passed to FIRST smuggle function\"\"\"\n",
+        "    line = \"\"\"from foo smuggle bar, \\\n",
+        "                               baz as spam, \\\n",
+        "                               qux    # pip: foo==0.0.1\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 52,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sCcYGt_AQFpb"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses():\n",
+        "    line = \"\"\"from foo smuggle (bar, baz as spam, qux)\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 53,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gLCfWNofQFrb"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_1():\n",
+        "    line = \"\"\"from foo smuggle (bar, \n",
+        "                                baz as spam, \n",
+        "                                qux)\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 54,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "f4RxjFx_vNyM"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_1_onion_1():\n",
+        "    line = \"\"\"from foo smuggle (bar,    # pip: foo==0.0.1\n",
+        "                                baz as spam, \n",
+        "                                qux)\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 55,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wYlMwMwPvN7r"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_1_onion_2():\n",
+        "    line = \"\"\"from foo smuggle (bar, \n",
+        "                                baz as spam, \n",
+        "                                qux)    # pip: foo==0.0.1\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 56,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pmrunSGUu6LA"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_2():\n",
+        "    line = \"\"\"from foo smuggle (\n",
+        "                  bar, \n",
+        "                  baz as spam, \n",
+        "                  qux\n",
+        "              )\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 57,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dHRTaLVevfBc"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_2_onion_1():\n",
+        "    line = \"\"\"from foo smuggle (    # pip: foo==0.0.1\n",
+        "                  bar, \n",
+        "                  baz as spam, \n",
+        "                  qux\n",
+        "              )\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 58,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bwg_NQNrvfET"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_2_onion_2():\n",
+        "    line = \"\"\"from foo smuggle (\n",
+        "                  bar, \n",
+        "                  baz as spam, \n",
+        "                  qux\n",
+        "              )    # pip: foo==0.0.1\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 59,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rYyjDKl6u6ND"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_from_parentheses_multiline_2_onion_2_comments():\n",
+        "    line = \"\"\"from foo smuggle (    # unrelated comment on first line\n",
+        "                  bar,    # unrelated comment on package name line\n",
+        "                  baz as spam, \n",
+        "                  # unrelated comment on its own line\n",
+        "                  qux\n",
+        "              )    # pip: foo==0.0.1    # unrelated comment after onion\"\"\"\n",
+        "    expected = _expected_parser_output('foo.bar', as_='bar', args_str='foo==0.0.1')\n",
+        "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
+        "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
+        "    expected += \"    # unrelated comment after onion\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 60,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "d7Jm83r9DJol"
+      },
+      "source": [
+        "@test\n",
+        "def test_parser_handles_smuggle_semicolons():\n",
+        "    \"\"\"also combines multiple elements from prior tests\"\"\"\n",
+        "    line = \"\"\"smuggle foo; smuggle bar as baz; \\\n",
+        "              from spam smuggle eggs; \\\n",
+        "              from qux smuggle quux as corge    # pip: qux-package==0.0.1\"\"\"\n",
+        "    expected = _expected_parser_output('foo')\n",
+        "    expected += f\"; {_expected_parser_output('bar', as_='baz')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam.eggs', as_='eggs')}\"\n",
+        "    expected += f\"; {_expected_parser_output('qux.quux', as_='corge', args_str='qux-package==0.0.1')}\"\n",
+        "    assert _matches_expected_output(expected, _parse_line(line))"
+      ],
+      "execution_count": 61,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zirSJGjJHV-V"
+      },
+      "source": [
+        "### onion comment parser tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0XhK1r5ou6PI"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_simple():\n",
+        "    onion = '# pip: foo==0.0.1'\n",
+        "    expected = _expected_onion_parser_output('foo==0.0.1')\n",
+        "    assert _parse_onion(onion) == expected"
+      ],
+      "execution_count": 62,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HVZceFWkRZA7"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_whitespace():\n",
+        "    onion = '#             pip:            foo==0.0.1'\n",
+        "    expected = _expected_onion_parser_output('foo==0.0.1')\n",
+        "    assert _parse_onion(onion) == expected"
+      ],
+      "execution_count": 63,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "d0IOshgRQvnk"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_github():\n",
+        "    onion = '# pip: git+https://github.com/foo/bar.git@branch-name#egg=foo&subdirectory=baz'\n",
+        "    expected = _expected_onion_parser_output('git+https://github.com/foo/bar.git@branch-name#egg=foo&subdirectory=baz')\n",
+        "    assert _parse_onion(onion) == expected"
+      ],
+      "execution_count": 64,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "M4gBOhCGu6Q1"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_editable():\n",
+        "    onion = '# pip: --editable git+https://github.com/foo/bar.git'\n",
+        "    expected = _expected_onion_parser_output('--editable git+https://github.com/foo/bar.git', \n",
+        "                                             editable=True, \n",
+        "                                             spec='git+https://github.com/foo/bar.git')\n",
+        "    assert _parse_onion(onion) == expected"
+      ],
+      "execution_count": 65,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "J8wQPpzzwXdc"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_joined_short_args():\n",
+        "    onion = '# pip: -Ive git+https://github.com/foo/bar.git'\n",
+        "    expected = _expected_onion_parser_output('-Ive git+https://github.com/foo/bar.git', \n",
+        "                                             editable=True, \n",
+        "                                             ignore_installed=True, \n",
+        "                                             verbosity=1,\n",
+        "                                             spec='git+https://github.com/foo/bar.git')\n",
+        "    assert _parse_onion(onion) == expected"
+      ],
+      "execution_count": 66,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "BM6uJdjyw7Ne"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_fails_mutually_exclusive_args():\n",
+        "    onion = '# pip: --use-pep517 --no-use-pep517 foo'\n",
+        "    try:\n",
+        "        _parse_onion(onion)    # SHOULD FAIL\n",
+        "    except davos.exceptions.OnionArgumentError as e:\n",
+        "        # has both 'msg' and 'message' attrs because it inherits from both \n",
+        "        # SyntaxError and argparse.ArgumentError\n",
+        "        assert e.msg == e.message == \"not allowed with argument --use-pep517\"\n",
+        "        assert e.argument_name == \"--no-use-pep517\"\n",
+        "        assert str(e) == \"argument --no-use-pep517: not allowed with argument --use-pep517\"\n",
+        "    else:\n",
+        "        raise DavosAssertionError(\"test should've raised 'davos.exceptions.OnionArgumentError'\")"
+      ],
+      "execution_count": 67,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AUC0oBgORDgT"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_fails_editable_after_spec():\n",
+        "    onion = '# pip: git+https://github.com/foo/bar.git#egg=foo --editable'\n",
+        "    try:\n",
+        "        _parse_onion(onion)    # SHOULD FAIL\n",
+        "    except davos.exceptions.OnionArgumentError as e:\n",
+        "        # has both 'msg' and 'message' attrs because it inherits from both \n",
+        "        # SyntaxError and argparse.ArgumentError\n",
+        "        assert e.msg == e.message == \"expected one argument\"\n",
+        "        assert e.argument_name == \"-e/--editable\"\n",
+        "        assert str(e) == \"argument -e/--editable: expected one argument\"\n",
+        "    else:\n",
+        "        raise DavosAssertionError(\"test should've raised 'davos.exceptions.OnionArgumentError'\")"
+      ],
+      "execution_count": 68,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CBWpL3xPqy62"
+      },
+      "source": [
+        "@test\n",
+        "def test_onion_parser_fails_arg_requires_value():\n",
+        "    onion = '# pip: foo==0.0.1 --platform '\n",
+        "    try:\n",
+        "        _parse_onion(onion)    # SHOULD FAIL\n",
+        "    except davos.exceptions.OnionArgumentError as e:\n",
+        "        # has both 'msg' and 'message' attrs because it inherits from both \n",
+        "        # SyntaxError and argparse.ArgumentError\n",
+        "        assert e.msg == e.message == \"expected one argument\"\n",
+        "        assert e.argument_name == \"--platform\"\n",
+        "        assert str(e) == \"argument --platform: expected one argument\"\n",
+        "    else:\n",
+        "        raise DavosAssertionError(\"test should've raised 'davos.exceptions.OnionArgumentError'\")"
+      ],
+      "execution_count": 69,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mobuRXLIzSYI"
+      },
+      "source": [
+        "### miscellaneous tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Ik7dWA_eKxZ1"
+      },
+      "source": [
+        "@test\n",
+        "def test_does_not_register_multiple_transformers():\n",
+        "    splitter_xforms = IPYTHON_SHELL.input_splitter.python_line_transforms\n",
+        "    manager_xforms = IPYTHON_SHELL.input_transformer_manager.python_line_transforms\n",
+        "    initial_n_splitter_xforms = len(splitter_xforms)\n",
+        "    initial_n_manager_xforms = len(manager_xforms)\n",
+        "    # record whether parser is active before running test to restore \n",
+        "    # initial state afterward\n",
+        "    start_active = davos.is_active()\n",
+        "    if not start_active:\n",
+        "        # ensure these are the number of registered transforms \n",
+        "        # *including the davos parser*\n",
+        "        initial_n_splitter_xforms += 1\n",
+        "        initial_n_manager_xforms += 1\n",
+        "\n",
+        "    try:\n",
+        "        for _ in range(5):\n",
+        "            davos.activate()\n",
+        "            assert len(splitter_xforms) == initial_n_splitter_xforms\n",
+        "            assert len(manager_xforms) == initial_n_manager_xforms\n",
+        "    finally:\n",
+        "        if not start_active:\n",
+        "            davos.deactivate()"
+      ],
+      "execution_count": 70,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "5MaNzcxkKIxW"
+      },
+      "source": [
+        "@test\n",
+        "def test_deactivate_reactivate():\n",
+        "    start_active = davos.is_active()\n",
+        "    try:\n",
+        "        # start with the parser active\n",
+        "        if not start_active:\n",
+        "            davos.activate()\n",
+        "        \n",
+        "        assert davos.is_active()\n",
+        "        davos.deactivate()\n",
+        "        assert not davos.is_active()\n",
+        "        davos.activate()\n",
+        "        assert davos.is_active()\n",
+        "    finally:\n",
+        "        # return to state before function\n",
+        "        if not start_active:\n",
+        "            davos.deactivate()"
+      ],
+      "execution_count": 71,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f6KNObdccm0Z"
+      },
+      "source": [
+        "## Integration tests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dAFOjVHdclYr"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_pypi_new():\n",
+        "    assert not _is_installed('ppca')\n",
+        "    smuggle ppca    # pip: ppca>=0.0.4\n",
+        "    assert isinstance(ppca, types.ModuleType)\n",
+        "    assert hasattr(ppca, 'PPCA')"
+      ],
+      "execution_count": 72,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xSmyvDGGez-g"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_from_pypi_new():\n",
+        "    assert not _is_installed('umap-learn')\n",
+        "    from umap smuggle UMAP    # pip: umap-learn==0.4.6\n",
+        "    assert hasattr(UMAP, 'fit')\n",
+        "    assert _is_installed('umap-learn==0.4.6')"
+      ],
+      "execution_count": 73,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VZcVIiqw2FNH"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_previously_installed():\n",
+        "    assert _is_installed('fastdtw==0.3.4')\n",
+        "    smuggle fastdtw    # pip: fastdtw==0.3.2\n",
+        "    assert _is_installed('fastdtw==0.3.2')"
+      ],
+      "execution_count": 74,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3i_NEWou3GJd"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_previously_imported():\n",
+        "    import tqdm\n",
+        "    assert tqdm.__version__ == '4.41.1'\n",
+        "    smuggle tqdm    # pip: tqdm==4.45.0\n",
+        "    assert tqdm.__version__ == '4.45.0'"
+      ],
+      "execution_count": 75,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CAwx5l_V3hfu"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_github_ref():\n",
+        "    assert not _is_installed('hypertools')\n",
+        "    smuggle hypertools as hyp    # pip: git+https://github.com/ContextLab/hypertools.git@36c12fd#egg=hypertools\n",
+        "    assert isinstance(hyp, types.ModuleType)\n",
+        "    assert hyp is sys.modules['hypertools']\n",
+        "    assert hasattr(hyp, 'DataGeometry')\n",
+        "    assert hyp.__version__ == '0.6.3'\n",
+        "    assert _is_installed('hypertools==0.6.3')"
+      ],
+      "execution_count": 76,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WjesOMYTzhap"
+      },
+      "source": [
+        "@test(timeout=30)\n",
+        "def test_smuggle_github_editable():\n",
+        "    assert not _is_installed('quail')\n",
+        "    smuggle quail    # pip: -e git+https://github.com/ContextLab/quail.git@v0.2.0#egg=quail --src /content/gh_clones\n",
+        "    assert '/content/gh_clones/quail' in sys.path\n",
+        "    assert isinstance(quail, types.ModuleType)\n",
+        "    assert hasattr(quail, 'Egg')\n",
+        "    assert _is_installed('quail==0.2.0')\n",
+        "    assert Path('/content/gh_clones/quail').is_dir()"
+      ],
+      "execution_count": 77,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4fzZ0fFL9bmF"
+      },
+      "source": [
+        "@test(timeout=300)\n",
+        "def test_smuggle_github_subdirectory():\n",
+        "    assert not _is_installed('sherlock_helpers')\n",
+        "    smuggle sherlock_helpers    # pip: git+https://github.com/ContextLab/sherlock-topic-model-paper.git@v1.0#subdirectory=code/sherlock_helpers\n",
+        "    assert isinstance(sherlock_helpers, types.ModuleType)\n",
+        "    assert hasattr(sherlock_helpers, 'github_url')\n",
+        "    assert sherlock_helpers.__version__ == '0.0.1'\n",
+        "    assert _is_installed('sherlock_helpers==0.0.1')"
+      ],
+      "execution_count": 78,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SgQcCroC4gqI"
+      },
+      "source": [
+        "# **Run main tests**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "HW5I9hyX3Nv9",
+        "outputId": "486b483a-a489-4e1f-b815-e200925e84f9"
+      },
+      "source": [
+        "run_tests()"
+      ],
+      "execution_count": 79,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1/50  test_run_shell_command_simple:                                                 passed\n",
+            "2/50  test_run_shell_command_multiword:                                              passed\n",
+            "3/50  test_run_shell_command_failure:                                                passed\n",
+            "4/50  test_parser_ignores_line_no_smuggle:                                           passed\n",
+            "5/50  test_parser_ignores_line_decoy_smuggle:                                        passed\n",
+            "6/50  test_parser_ignores_commented_line:                                            passed\n",
+            "7/50  test_parser_handles_basic_line:                                                passed\n",
+            "8/50  test_parser_handles_basic_line_alias:                                          passed\n",
+            "9/50  test_parser_handles_basic_line_onion:                                          passed\n",
+            "10/50 test_parser_ignores_non_onion_comment:                                         passed\n",
+            "11/50 test_parser_ignores_imposter_onion_comment:                                    passed\n",
+            "12/50 test_parser_handles_smuggle_qualname:                                          passed\n",
+            "13/50 test_parser_handles_indented_line:                                             passed\n",
+            "14/50 test_parser_handles_different_install_name:                                    passed\n",
+            "15/50 test_parser_handles_multiple_packages:                                         passed\n",
+            "16/50 test_parser_handles_multiple_packages_onion:                                   passed\n",
+            "17/50 test_parser_handles_backslash:                                                 passed\n",
+            "18/50 test_parser_handles_backslash_onion:                                           passed\n",
+            "19/50 test_parser_handles_inconsistent_whitespace:                                   passed\n",
+            "20/50 test_parser_handles_smuggle_from:                                              passed\n",
+            "21/50 test_parser_handles_smuggle_from_onion:                                        passed\n",
+            "22/50 test_parser_handles_smuggle_from_multi:                                        passed\n",
+            "23/50 test_parser_handles_smuggle_from_multi_onion:                                  passed\n",
+            "24/50 test_parser_handles_smuggle_from_backslash:                                    passed\n",
+            "25/50 test_parser_handles_smuggle_from_parentheses:                                  passed\n",
+            "26/50 test_parser_handles_smuggle_from_parentheses_multiline_1:                      passed\n",
+            "27/50 test_parser_handles_smuggle_from_parentheses_multiline_1_onion_1:              passed\n",
+            "28/50 test_parser_handles_smuggle_from_parentheses_multiline_1_onion_2:              passed\n",
+            "29/50 test_parser_handles_smuggle_from_parentheses_multiline_2:                      passed\n",
+            "30/50 test_parser_handles_smuggle_from_parentheses_multiline_2_onion_1:              passed\n",
+            "31/50 test_parser_handles_smuggle_from_parentheses_multiline_2_onion_2:              passed\n",
+            "32/50 test_parser_handles_smuggle_from_parentheses_multiline_2_onion_2_comments:     passed\n",
+            "33/50 test_parser_handles_smuggle_semicolons:                                        passed\n",
+            "34/50 test_onion_parser_simple:                                                      passed\n",
+            "35/50 test_onion_parser_whitespace:                                                  passed\n",
+            "36/50 test_onion_parser_github:                                                      passed\n",
+            "37/50 test_onion_parser_editable:                                                    passed\n",
+            "38/50 test_onion_parser_joined_short_args:                                           passed\n",
+            "39/50 test_onion_parser_fails_mutually_exclusive_args:                               passed\n",
+            "40/50 test_onion_parser_fails_editable_after_spec:                                   passed\n",
+            "41/50 test_onion_parser_fails_arg_requires_value:                                    passed\n",
+            "42/50 test_does_not_register_multiple_transformers:                                  passed\n",
+            "43/50 test_deactivate_reactivate:                                                    passed\n",
+            "44/50 test_smuggle_pypi_new:                                                         passed\n",
+            "45/50 test_smuggle_from_pypi_new:                                                    passed\n",
+            "46/50 test_smuggle_previously_installed:                                             passed\n",
+            "47/50 test_smuggle_previously_imported:                                              passed\n",
+            "48/50 test_smuggle_github_ref:                                                       passed\n",
+            "49/50 test_smuggle_github_editable:                                                  passed\n",
+            "50/50 test_smuggle_github_subdirectory:                                              "
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/markdown": "Helper functions and variables used across multiple notebooks can be found in `/usr/local/lib/python3.7/dist-packages/sherlock_helpers`, or on GitHub, [here](https://github.com/ContextLab/sherlock-topic-model-paper/tree/master/code/sherlock_helpers).<br />You can also view source code directly from the notebook with:<br /><pre>    from sherlock_helpers.functions import show_source<br />    show_source(foo)</pre>",
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "passed\n",
+            "\n",
+            "\n",
+            "\n",
+            "All tests passed!\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- more efficient parser
- ability to interactively disable/re-enable davos parser
    - and test whether or not it's currently active
- more verbose post-parsing `smuggle()` "function form" that contains more information in kwarg values
- more efficient logic and checks for currently installed package versions in main smuggle function
    - checks for currently installed package versions are also now sensitive to just-installed packages
- much more effective module reloading after installation
- very basic cache for previously smuggled modules
- (pseudo-)reimplemented pip-install CLI parser for easier mapping between short & long argument names
- handling for packages installed with `-t/--target`, or `-e/--editable` VCS installs with `--src`, `#egg=<project_name>`, `&subdirectory=<subdir_name>`, etc.
- improved custom exception classes
    - exceptions raised during parser step inherit from SyntaxError so they can be raised
    - SyntaxError-derived exceptions point to location of error in code (like SyntaxError does)
    - on import, davos overrides `IPython.core.interactiveshell.InteractiveShell.showsyntaxerror()` with custom code to redirect display formatting for davos-related errors and show full traceback (normal SyntaxError display showone because there usually isn't one)
    - removed some excess classes from the inheritance hierarchy
- 12 notebook environment setup/validation tests + 50 unit/integration tests for davos use in Colab
- numerous other bug fixes

- closes #1 
- closes #2
- closes #3  
- closes #8