### PR TITLE
whitespace insensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ assert np.__version__ == '1.20.2'
     - [Compare behavior across package versions](#compare-behavior-across-package-versions)
 - [Usage](#usage)
   - [The `smuggle` Statement](#the-smuggle-statement)
+    - [Syntax](#smuggle-statement-syntax)
+    - [Rules](#smuggle-statement-rules)
   - [The Onion Comment](#the-onion-comment)
+    - [Syntax](#onion-comment-syntax)
+    - [Rules](#onion-comment-rules)
   - [Customizing `davos` Behavior](#customizing-davos-behavior)
 - [Examples](#examples)
 - [How it works](#how-it-works)
@@ -207,6 +211,7 @@ print(result1 == result2 == result3)
 
 ## Usage
 ### The `smuggle` Statement
+#### <a name="smuggle-statement-syntax"></a>Syntax
 The `smuggle` statement is designed to be used in place of 
 [the built-in `import` statement](https://docs.python.org/3/reference/import.html) and shares
 [its full syntactic definition](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement):
@@ -231,6 +236,23 @@ In simpler terms, any valid syntax for `import` is also a valid syntax for `smug
 smuggle baz as qux`, etc.). See [below](#valid-syntaxes) for a full list of valid forms.
 
 
+#### <a name="smuggle-statement-rules"></a>Rules
+- Like `import` statements, `smuggle` statements are whitespace-insensitive, except when a lack of whitespace between 
+  two tokens would cause them to be interpreted as a different token:
+  ```python
+  from   os      . path    smuggle  dirname     ,join        as    opj    # valid
+  from os.path smuggle join asopj                            # invalid
+  ```
+- Any context that would prevent an `import` statement from being executed will do the same to a `smuggle` statement:
+  ```python
+  # smuggle numpy as np           # not executed
+  foo = """
+  smuggle numpy as np"""          # not executed
+  print('smuggle numpy as np')    # not executed
+  ```
+- Because the `davos` parser is, of course, less complex than the full Python parser, there are a couple edge cases in which the built-in `import` statement 
+
+
 ### The Onion Comment
 An _onion comment_ is a special type of inline comment placed on a line containing a `smuggle` statement. Onion comments 
 can be used to control how `davos`:
@@ -238,6 +260,8 @@ can be used to control how `davos`:
 - determines whether the `smuggle`d package should be installed
 - installs the `smuggle`d package, if necessary
 
+
+#### <a name="onion-comment-syntax"></a>Syntax
 Onion comments follow a simple but specific syntax, inspired in part by the 
 [type comment syntax](https://www.python.org/dev/peps/pep-0484/#type-comments) introduced in 
 [PEP 484](https://www.python.org/dev/peps/pep-0484). The following is a loose (pseudo-)syntactic definition for an onion 
@@ -263,6 +287,10 @@ In practice, are identified as matches for the [regular expression](https://en.w
 ```regex
 #+ *(?:pip|conda) *: *[^# ].+?(?= +#| *\n| *$)
 ```
+
+
+#### <a name="onion-comment-rules"></a>Rules
+onion comment rules
 
 
 ### Customizing `davos` Behavior

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ install the package, restart the interpreter to make the new package available, 
 
 `smuggle`, however, can handle missing packages on the fly. If you `smuggle` a package that isn't installed locally, 
 `davos` will install it, immediately make its contents accessible to the interpreter's
-[import machinery](https://docs.python.org/3.9/reference/import.html), and load the package into the local namespace for 
+[import machinery](https://docs.python.org/3/reference/import.html), and load the package into the local namespace for 
 use. You can also add an inline ["onion" comment](#the-onion-comment) after a `smuggle` statement to customize how 
 `davos` will install the package, if it can't be found locally.
 
@@ -123,13 +123,13 @@ differences between revisions (e.g., commits) within the same semantic version.
 **`davos` solves these issues** by allowing you to constrain each package you `smuggle` to a specific version or range 
 of acceptable versions. This can be done simply by placing a 
 [version specifier](https://www.python.org/dev/peps/pep-0440/#version-specifiers) in an 
-[onion comment](#the-onion-comment) next to the corresponding smuggle statement:
+[onion comment](#the-onion-comment) next to the corresponding `smuggle` statement:
 ```python
 smuggle numpy as np              # pip: numpy==1.20.2
 from pandas smuggle DataFrame    # pip: pandas>=0.23,<1.0
 ```
 In this example, the first line will load [`numpy`](https://numpy.org/) into the local namespace under the alias "`np`", 
-just as" `import numpy as np`" would. `davos` will first check whether `numpy` is installed locally, and if so, whether 
+just as "`import numpy as np`" would. `davos` will first check whether `numpy` is installed locally, and if so, whether 
 the installed version _exactly_ matches `1.20.2`. If `numpy` is not installed, or the installed version is anything 
 other than `1.20.2`, `davos` will use the specified _installer_, `pip`, to install `numpy==1.20.2` before loading the 
 package. 
@@ -198,7 +198,7 @@ result1 = mypkg.my_func(data)
 smuggle mypkg                    # pip: mypkg==0.2
 result2 = mypkg.my_func(data)
 
-smuggle mypkg                    # pip: git+https://github.com/MyOrg/MyRepo.git#egg=mypkg
+smuggle mypkg                    # pip: git+https://github.com/MyOrg/mypkg.git
 result3 = mypkg.my_func(data)
 
 print(result1 == result2 == result3)
@@ -211,7 +211,7 @@ The `smuggle` statement is designed to be used in place of
 [the built-in `import` statement](https://docs.python.org/3/reference/import.html) and shares
 [its full syntactic definition](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement):
 ```ebnf
-smuggle_stmt     ::=  "smuggle" module ["as" identifier] ("," module ["as" identifier])*
+smuggle_stmt    ::=  "smuggle" module ["as" identifier] ("," module ["as" identifier])*
                      | "from" relative_module "smuggle" identifier ["as" identifier]
                      ("," identifier ["as" identifier])*
                      | "from" relative_module "smuggle" "(" identifier ["as" identifier]
@@ -220,12 +220,52 @@ smuggle_stmt     ::=  "smuggle" module ["as" identifier] ("," module ["as" ident
 module          ::=  (identifier ".")* identifier
 relative_module ::=  "."* module | "."+
 ```
+
+_NB: uses the modified BNF grammar notation described 
+[here](https://docs.python.org/3/reference/introduction.html#notation) in 
+[The Python Language Reference](https://docs.python.org/3/reference); see 
+[here](https://docs.python.org/3/reference/lexical_analysis.html#identifiers) for the lexical definition of 
+`identifier`_
+
 In simpler terms, any valid syntax for `import` is also a valid syntax for `smuggle` (`smuggle foo`, `from foo.bar 
 smuggle baz as qux`, etc.). See [below](#valid-syntaxes) for a full list of valid forms.
 
 
 ### The Onion Comment
-### Enabling & Disabling `davos`
+An _onion comment_ is a special type of inline comment placed on a line containing a `smuggle` statement. Onion comments 
+can be used to control how `davos`:
+
+- determines whether the `smuggle`d package should be installed
+- installs the `smuggle`d package, if necessary
+
+Onion comments follow a simple but specific syntax, inspired in part by the 
+[type comment syntax](https://www.python.org/dev/peps/pep-0484/#type-comments) introduced in 
+[PEP 484](https://www.python.org/dev/peps/pep-0484). The following is a loose (pseudo-)syntactic definition for an onion 
+comment:
+```ebnf
+onion_comment   ::=  "#" installer ":" install_opt* pkg_spec install_opt*
+installer       ::=  ("pip" | "conda")
+pkg_spec        ::=  identifier [version_spec]
+```
+where the `installer` is the program used to install the package, an `install_opt` is an option accepted by the 
+`installer` program's "`install`" command, and an `identifier` is used as defined 
+[here](https://docs.python.org/3/reference/lexical_analysis.html#identifiers). 
+
+The `version_spec` may be a [version specifier](https://www.python.org/dev/peps/pep-0440/#version-specifiers) defined by 
+[PEP 440](https://www.python.org/dev/peps/pep-0440), or an alternative syntax valid for the `installer` program. For 
+example, `pip` uses specific syntax for [local](https://pip.pypa.io/en/stable/cli/pip_install/#local-project-installs), 
+[editable](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs), and 
+[VCS-based](https://pip.pypa.io/en/stable/cli/pip_install/#vcs-support) installation while `conda` supports 
+[additional specifiers](https://pip.pypa.io/en/stable/cli/pip_install/#vcs-support) and installing specific package 
+builds.
+
+In practice, are identified as matches for the [regular expression](https://en.wikipedia.org/wiki/Regular_expression):
+```regex
+#+ *(?:pip|conda) *: *[^# ].+?(?= +#| *\n| *$)
+```
+
+
+### Customizing `davos` Behavior
 ## Examples
 ### Valid Syntaxes
 ## How it works

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -365,13 +365,13 @@ def smuggle_parser_colab(line):
     for na in names_aliases:
         if ' as ' in na:
             name, alias = na.split(' as ')
-            name = f'"{qualname_prefix}{name.strip()}"'
+            name = f'"{qualname_prefix}{name}"'
             alias = f'"{alias.strip()}"'
         else:
-            na = na.strip()
             name = f'"{qualname_prefix}{na}"'
-            alias = f'"{na}"' if is_from_statement else None
+            alias = f'"{na.strip()}"' if is_from_statement else None
 
+        name = name.replace(' ', '')
         smuggle_funcs.append(f'smuggle(name={name}, as_={alias})')
 
     smuggle_funcs[0] = smuggle_funcs[0][:-1] + kwargs_str + ')'

--- a/davos/colab.py
+++ b/davos/colab.py
@@ -320,28 +320,36 @@ def smuggle_parser_colab(line):
     smuggle_chars = matched_groups['FULL_CMD']
     before_chars, after_chars = line.split(smuggle_chars)
     cmd_prefix, to_smuggle = smuggle_chars.split('smuggle ', maxsplit=1)
+    cmd_prefix = cmd_prefix.strip()
+    to_smuggle = to_smuggle.strip()
 
     if cmd_prefix:
-        # cmd_prefix == 'from <package[.module[...]]> '
+        # cmd_prefix == '"from" package[.module[...]] '
         is_from_statement = True
         onion_chars = matched_groups['FROM_ONION'] or matched_groups['FROM_ONION_1']
         has_semicolon_sep = matched_groups['FROM_SEMICOLON_SEP'] is not None
-        qualname_prefix = cmd_prefix.split()[1] + '.'
-        to_smuggle = re.sub(r'[()]|\s*\#.*$\s*', ' ', to_smuggle, flags=re.M)
-        to_smuggle = to_smuggle.rstrip(', ')
+        qualname_prefix = f"{''.join(cmd_prefix.split()[1:])}."
+        # remove parentheses around line continuations
+        to_smuggle = to_smuggle.replace(')', '').replace('(', '')
+        # remove inline comments
+        if '\n' in to_smuggle:
+            to_smuggle = ' '.join(l.split('#')[0] for l in to_smuggle.splitlines())
+        else:
+            to_smuggle = to_smuggle.split('#')[0]
+        # normalize whitespace
+        to_smuggle = ' '.join(to_smuggle.split()).strip(', ')
     else:
         # cmd_prefix == ''
         is_from_statement = False
         onion_chars = matched_groups['ONION']
-        if onion_chars is not None:
-            onion_chars = onion_chars.replace('"', "'")
         has_semicolon_sep = matched_groups['SEMICOLON_SEP'] is not None
         qualname_prefix = ''
 
-    kwargs_str = ''
+    kwargs_str = ''        
     if has_semicolon_sep:
         after_chars = '; ' + smuggle_parser_colab(after_chars.lstrip('; '))
     elif onion_chars is not None:
+        onion_chars = onion_chars.replace('"', "'")
         to_smuggle = to_smuggle.replace(onion_chars, '').rstrip()
         # `Onion.parse_onion()` returns a 3-tuple of:
         #  - the installer name (str)

--- a/davos/core.py
+++ b/davos/core.py
@@ -206,7 +206,7 @@ class Onion:
                        f"exit code: {e.returncode}. See above output "
                        f"for details")
             raise InstallerError(err_msg, e)
-        # hanle packages installed in non-standard locations
+        # handle packages installed in non-standard locations
         install_dir = self.installer_kwargs.get('target')
         if install_dir is not None and install_dir not in sys.path:
             # make sure alternate target directory is in the module
@@ -276,7 +276,7 @@ def prompt_input(prompt, default=None, interrupt=None):
 _smuggle_subexprs = {
     'name_re': r'[a-zA-Z]\w*',
     'qualname_re': r'[a-zA-Z][\w.]*\w',
-    'onion_re': r'\#+ *pip:.+?(?= +\#| *\n| *$)',
+    'onion_re': r'\#+ *(?:pip|conda) *: *[^# ].+?(?= +\#| *\n| *$)',
     'comment_re': r'(?m:\#+.*$)'
 }
 _smuggle_subexprs['as_re'] = fr' +as +{_smuggle_subexprs["name_re"]}'

--- a/davos/core.py
+++ b/davos/core.py
@@ -377,19 +377,19 @@ smuggle_statement_regex = re.compile((
 
 
 # Condensed, fully substituted regex:
-# ^\s*(?P<FULL_CMD>(?:smuggle +[a-zA-Z]\w*(?: *\. *[a-zA-Z]\w*)*(?: +as
+# ^\s*(?P<FULL_CMD>(?:smuggle +[a-zA-Z]\w*(?: *\. *[a-zA-Z]\w*)*(?: +as 
 # +[a-zA-Z]\w*)?(?: *, *[a-zA-Z]\w*(?: *\. *[a-zA-Z]\w*)*(?: +as +[a-zA-
 # Z]\w*)?)*(?P<SEMICOLON_SEP>(?= *; *(?:smuggle|from)))?(?(SEMICOLON_SEP
-# )|(?: *(?=\#+ *(?:pip|conda) *: *[^# ].+?(?= +\#| *\n| *$))(?P<ONION>\
-# #+ *(?:pip|conda) *: *[^# ].+?(?= +\#| *\n| *$))?)?))|(?:from *[a-zA-Z
-# ]\w*(?: *\. *[a-zA-Z]\w*)* +smuggle +(?P<OPEN_PARENS>\()?(?(OPEN_PAREN
-# S)(?: *(?:[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *(?:, *[a-zA-Z]\w*(?: +as
-# +[a-zA-Z]\w*)? *)*,? *)?(?:(?P<FROM_ONION_1>\#+ *(?:pip|conda) *: *[^#
-#  ].+?(?= +\#| *\n| *$)) *(?m:\#+.*$)?|(?m:\#+.*$)|(?m:$)|(?P<CLOSE_PAR
-# ENS_FIRSTLINE>\)))(?(CLOSE_PARENS_FIRSTLINE)|(?:\s*(?:[a-zA-Z]\w*(?: +
-# as +[a-zA-Z]\w*)? *(?:, *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *)*[^)\n]*|
-#  *(?m:\#+.*$)|\n *))*\)))|[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?(?: *, *[a-
-# zA-Z]\w*(?: +as +[a-zA-Z]\w*)?)*)(?P<FROM_SEMICOLON_SEP>(?= *; *(?:smu
-# ggle|from)))?(?(FROM_SEMICOLON_SEP)|(?(FROM_ONION_1)|(?: *(?=\#+ *(?:p
-# ip|conda) *: *[^# ].+?(?= +\#| *\n| *$))(?P<FROM_ONION>\#+ *(?:pip|con
-# da) *: *[^# ].+?(?= +\#| *\n| *$)))?))))
+# )|(?: *(?=\#+ *(?:pip|conda) *: *[^#\n ].+?(?= +\#| *\n| *$))(?P<ONION
+# >\#+ *(?:pip|conda) *: *[^#\n ].+?(?= +\#| *\n| *$))?)?))|(?:from *[a-
+# zA-Z]\w*(?: *\. *[a-zA-Z]\w*)* +smuggle +(?P<OPEN_PARENS>\()?(?(OPEN_P
+# ARENS)(?: *(?:[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *(?:, *[a-zA-Z]\w*(?:
+# +as +[a-zA-Z]\w*)? *)*,? *)?(?:(?P<FROM_ONION_1>\#+ *(?:pip|conda) *:
+# *[^#\n ].+?(?= +\#| *\n| *$)) *(?m:\#+.*$)?|(?m:\#+.*$)|(?m:$)|(?P<CLO
+# SE_PARENS_FIRSTLINE>\)))(?(CLOSE_PARENS_FIRSTLINE)|(?:\s*(?:[a-zA-Z]\w
+# *(?: +as +[a-zA-Z]\w*)? *(?:, *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)? *)*[^
+# )\n]*| *(?m:\#+.*$)|\n *))*\)))|[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?(?: *
+# , *[a-zA-Z]\w*(?: +as +[a-zA-Z]\w*)?)*)(?P<FROM_SEMICOLON_SEP>(?= *; *
+# (?:smuggle|from)))?(?(FROM_SEMICOLON_SEP)|(?(FROM_ONION_1)|(?: *(?=\#+
+#  *(?:pip|conda) *: *[^#\n ].+?(?= +\#| *\n| *$))(?P<FROM_ONION>\#+ *(?
+# :pip|conda) *: *[^#\n ].+?(?= +\#| *\n| *$)))?))))

--- a/davos/core.py
+++ b/davos/core.py
@@ -32,8 +32,9 @@ class Onion:
     def parse_onion(onion_text):
         onion_text = onion_text.lstrip('# ')
         installer, args_str = onion_text.split(':', maxsplit=1)
-        # remove all space between '<installer>:' and '<args_str>'
-        args_str = args_str.lstrip()
+        # normalize whitespace
+        installer = installer.strip()
+        args_str = ' '.join(args_str.split()).strip()
         # regex parsing to identify onion comments already ensures the
         # comment will start with "<installer>:"
         if installer == 'pip':

--- a/davos/core.py
+++ b/davos/core.py
@@ -278,7 +278,7 @@ _smuggle_subexprs = {
     'name_re': _name_re,
     'qualname_re': fr'{_name_re}(?: *\. *{_name_re})*',
     'as_re': fr' +as +{_name_re}',
-    'onion_re': r'\#+ *(?:pip|conda) *: *[^# ].+?(?= +\#| *\n| *$)',
+    'onion_re': r'\#+ *(?:pip|conda) *: *[^#\n ].+?(?= +\#| *\n| *$)',
     'comment_re': r'(?m:\#+.*$)'
 }
 

--- a/tests/test_davos_colab.ipynb
+++ b/tests/test_davos_colab.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "test-davos-colab.ipynb",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -638,7 +639,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "QMvGVihj4l-D",
-        "outputId": "8a7bc4a4-bd32-45f6-9f2a-866c35793a90"
+        "outputId": "1c945267-f2e3-4832-b340-bdcb127204d1"
       },
       "source": [
         "run_setup(source='github', fork='paxtonfitzpatrick')"
@@ -655,15 +656,15 @@
             "5/12 test_ipython_version:                                  passed\n",
             "6/12 test_no_transforms_registered:                         passed\n",
             "7/12 test_install_davos:                                    Collecting davos\n",
-            "  Cloning https://github.com/paxtonfitzpatrick/davos.git to /tmp/pip-install-tgjr5kp0/davos\n",
-            "  Running command git clone -q https://github.com/paxtonfitzpatrick/davos.git /tmp/pip-install-tgjr5kp0/davos\n",
+            "  Cloning https://github.com/paxtonfitzpatrick/davos.git to /tmp/pip-install-sgjxfs1o/davos\n",
+            "  Running command git clone -q https://github.com/paxtonfitzpatrick/davos.git /tmp/pip-install-sgjxfs1o/davos\n",
             "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
             "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
             "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
             "Building wheels for collected packages: davos\n",
             "  Building wheel for davos (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for davos: filename=davos-0.0.1-cp37-none-any.whl size=27256 sha256=386b5cbd872b78a7d1112dca7f850c1e82c7eaf3caf0c4c645a3ec20b7accbe0\n",
-            "  Stored in directory: /tmp/pip-ephem-wheel-cache-5z6d2tok/wheels/6d/b5/22/60574bf4074226d4d9c357fbfe356cb75b8eda276caa67e403\n",
+            "  Created wheel for davos: filename=davos-0.0.1-cp37-none-any.whl size=34545 sha256=847e52e1511283ba9deb9a24ca4a34c33d05cbfa4e0637509782881cb5161422\n",
+            "  Stored in directory: /tmp/pip-ephem-wheel-cache-al_oeui3/wheels/6d/b5/22/60574bf4074226d4d9c357fbfe356cb75b8eda276caa67e403\n",
             "Successfully built davos\n",
             "Installing collected packages: davos\n",
             "Successfully installed davos-0.0.1\n",
@@ -1040,14 +1041,12 @@
         "@test\n",
         "def test_parser_handles_inconsistent_whitespace():\n",
         "    \"\"\"should handle weird amounts of whitespace that are *technically* valid\"\"\"\n",
-        "    line = \"\"\"smuggle               foo as bar, \\\n",
-        "baz as qux, \\\n",
-        "                      spam,ham,eggs                        # pip:         foo==0.0.1    \"\"\"\n",
+        "    line = \"\"\"smuggle               foo     as    bar    \\\n",
+        ",baz as qux  , \\\n",
+        "          spam  .  ham    as    eggs                #   pip   :       foo==0.0.1    \"\"\"\n",
         "    expected = _expected_parser_output('foo', as_='bar', args_str='foo==0.0.1')\n",
         "    expected += f\"; {_expected_parser_output('baz', as_='qux')}\"\n",
-        "    expected += f\"; {_expected_parser_output('spam')}\"\n",
-        "    expected += f\"; {_expected_parser_output('ham')}\"\n",
-        "    expected += f\"; {_expected_parser_output('eggs')}\"\n",
+        "    expected += f\"; {_expected_parser_output('spam.ham', as_='eggs')}\"\n",
         "    # real parser adds back leading & trailing characters (including whitespace)\n",
         "    expected += \"    \"\n",
         "    assert _matches_expected_output(expected, _parse_line(line))"
@@ -1150,7 +1149,8 @@
       "source": [
         "@test\n",
         "def test_parser_handles_smuggle_from_parentheses():\n",
-        "    line = \"\"\"from foo smuggle (bar, baz as spam, qux)\"\"\"\n",
+        "    line = \"\"\"from foo smuggle (bar, baz as spam, qux,)\"\"\"\n",
+        "    # also tests trailing comma inside parentheses, which is valid\n",
         "    expected = _expected_parser_output('foo.bar', as_='bar')\n",
         "    expected += f\"; {_expected_parser_output('foo.baz', as_='spam')}\"\n",
         "    expected += f\"; {_expected_parser_output('foo.qux', as_='qux')}\"\n",
@@ -1696,7 +1696,7 @@
           "height": 1000
         },
         "id": "HW5I9hyX3Nv9",
-        "outputId": "486b483a-a489-4e1f-b815-e200925e84f9"
+        "outputId": "fa075155-f720-4e59-d577-d04a937dd453"
       },
       "source": [
         "run_tests()"


### PR DESCRIPTION
`smuggle` statements and onion comments are now insensitive to the amount of whitespace between tokens, in keeping with the `import` statement.  Absence of whitespace is disallowed when it would cause two tokens to instead be parsed as a different token (again, analogous to `import`). For example:
```python
from   os      . path    smuggle  dirname     ,join        as    opj    # valid <-- \
                                                                                   #|-- equivalent
from os.path smuggle join as opj                                        # valid <-- /

from os.path smuggle join asopj                                         # invalid
```