### PR TITLE
add CITATION.cff 

### DIFF
--- a/.github/workflows/ci-tests-colab.yml
+++ b/.github/workflows/ci-tests-colab.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - 'paper/**'
       - '.gitattributes'
+      - '.gitmodules'
+      - 'CITATION.cff'
       - 'LICENSE'
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/ci-tests-jupyter.yml
+++ b/.github/workflows/ci-tests-jupyter.yml
@@ -5,12 +5,16 @@ on:
     paths-ignore:
       - 'paper/**'
       - '.gitattributes'
+      - '.gitmodules'
+      - 'CITATION.cff'
       - 'LICENSE'
       - 'README.md'
   pull_request:
     paths-ignore:
       - 'paper/**'
       - '.gitattributes'
+      - '.gitmodules'
+      - 'CITATION.cff'
       - 'LICENSE'
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/request-colab-tests.yml
+++ b/.github/workflows/request-colab-tests.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - 'paper/**'
       - '.gitattributes'
+      - '.gitmodules'
+      - 'CITATION.cff'
       - 'LICENSE'
       - 'README.md'
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,54 @@
+authors:
+  - given-names: "Paxton C."
+    family-names: Fitzpatrick
+    email: "Paxton.C.Fitzpatrick.GR@Dartmouth.edu"
+    affiliation: Dartmouth College
+    orcid: "https://orcid.org/0000-0003-0205-3088"
+  - given-names: "Jeremy R."
+    family-names: Manning
+    email: "Jeremy.R.Manning@Dartmouth.edu"
+    affiliation: "Dartmouth College"
+    orcid: "https://orcid.org/0000-0001-7613-4732"
+cff-version: 1.2.0
+date-released: "2022-11-23"
+keywords:
+  - Reproducibility
+  - "Open science"
+  - Python
+  - "Jupyter notebook"
+  - IPython
+  - "Google Colab"
+  - "Package management"
+license: MIT
+license-url: "https://github.com/ContextLab/davos/blob/main/LICENSE"
+message: "If you use this software, please cite the associated paper (see preferred-citation)."
+preferred-citation:
+  authors:
+    - given-names: "Paxton C."
+      family-names: Fitzpatrick
+      email: "Paxton.C.Fitzpatrick.GR@Dartmouth.edu"
+      affiliation: Dartmouth College
+      orcid: "https://orcid.org/0000-0003-0205-3088"
+      website: "https://paxtonfitzpatrick.me"
+    - given-names: "Jeremy R."
+      family-names: Manning
+      email: "Jeremy.R.Manning@Dartmouth.edu"
+      affiliation: "Dartmouth College"
+      orcid: "https://orcid.org/0000-0001-7613-4732"
+      website: "https://www.context-lab.com"
+  date-published: "2022-11-23"
+  doi: 10.48550/arXiv.2211.15445
+  journal: arXiv
+  keywords:
+    - "Other Computer Science (cs.OH)"
+    - "FOS: Computer and information sciences"
+  month: 11
+  title: "$\texttt{davos}$: a Python package \"smuggler\" for constructing lightweight reproducible notebooks"
+  type: article
+  url: "https://arxiv.org/abs/2211.15445"
+  year: "2022"
+repository-code: "https://github.com/ContextLab/davos"
+repository-artifact: "https://pypi.org/project/davos/"
+title: davos
+type: software
+version: v0.1.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -43,7 +43,7 @@ preferred-citation:
     - "Other Computer Science (cs.OH)"
     - "FOS: Computer and information sciences"
   month: 11
-  title: "$\texttt{davos}$: a Python package \"smuggler\" for constructing lightweight reproducible notebooks"
+  title: "$\\texttt{davos}$: a Python package \"smuggler\" for constructing lightweight reproducible notebooks"
   type: article
   url: "https://arxiv.org/abs/2211.15445"
   year: "2022"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
   <a href="https://arxiv.org/abs/2211.15445">
     <img src="https://img.shields.io/badge/arXiv-2211.15445-b31b1b" alt="link to arXiv paper">
   </a>
-  <img src="https://img.shields.io/codefactor/grade/github/paxtonfitzpatrick/davos/main?logo=codefactor&logoColor=brightgreen" alt="code quality (CodeFactor)">
+  <a href="https://www.codefactor.io/repository/github/contextlab/davos">
+    <img src="https://img.shields.io/codefactor/grade/github/ContextLab/davos/main?logo=codefactor&logoColor=brightgreen" alt="code quality (CodeFactor)">
+  </a>
   <img src="https://img.shields.io/badge/mypy-type%20checked-blue" alt="mypy: checked">
   <br>
   <a href="https://github.com/ContextLab/davos/blob/main/LICENSE">


### PR DESCRIPTION
Citation file for repo that points to arXiv preprint.


Also:
- fixed "code quality" (codefactor) endpoint to use ContextLab repo and link to CodeFactor page when clicked.
- updated workflow configs to not trigger CI tests on changes to new non-code paths (`CITATION.cff`, `.gitmodules`)