### PR TITLE
bug fix for project type determination in colab notebooks

### DIFF
--- a/davos/core/project.py
+++ b/davos/core/project.py
@@ -305,17 +305,6 @@ class Project(metaclass=ProjectChecker):
             (i.e., no packages have been installed into it).
         """
         new_project_name, new_project_type = _get_project_name_type(new_name)
-        if config.environment == 'Colaboratory':
-            # colab name/type logic works slightly differently and needs
-            # to be handled separately
-            new_project_name = Path(new_project_name).name
-            # currently running notebook should be the only "real" one
-            # for the current VM session
-            curr_nb_name = get_notebook_path()
-            if new_project_name == curr_nb_name:
-                new_project_type = ConcreteProject
-            else:
-                new_project_type = AbstractProject
         if new_project_name == self.name:
             # no change
             return
@@ -504,6 +493,14 @@ def _get_project_name_type(project_name):
         )
 
     project_type = ConcreteProject
+    if config.environment == 'Colaboratory':
+        # colab name/type logic works slightly differently -- there's
+        # only ever one "real" notebook per VM session, but it doesn't
+        # exist on the VM filesystem
+        curr_notebook_name = get_notebook_path()
+        if project_name == curr_notebook_name:
+            return project_name, project_type
+        return project_name, AbstractProject
     if project_name.endswith('.ipynb'):
         # `project_name` is a path to a notebook file, either the
         # default (absolute path to the current notebook) or

--- a/davos/core/project.py
+++ b/davos/core/project.py
@@ -305,6 +305,17 @@ class Project(metaclass=ProjectChecker):
             (i.e., no packages have been installed into it).
         """
         new_project_name, new_project_type = _get_project_name_type(new_name)
+        if config.environment == 'Colaboratory':
+            # colab name/type logic works slightly differently and needs
+            # to be handled separately
+            new_project_name = Path(new_project_name).name
+            # currently running notebook should be the only "real" one
+            # for the current VM session
+            curr_nb_name = get_notebook_path()
+            if new_project_name == curr_nb_name:
+                new_project_type = ConcreteProject
+            else:
+                new_project_type = AbstractProject
         if new_project_name == self.name:
             # no change
             return
@@ -849,5 +860,8 @@ def use_default_project():
     else:
         proj_name = get_notebook_path()
 
-    default_project = Project(proj_name)
+    # will always be an absolute path to a real Jupyter notebook file,
+    # or name of real Colab notebook, so we can skip project type
+    # decision logic
+    default_project = ConcreteProject(proj_name)
     config.project = default_project

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = davos
-version = 0.2.0
+version = 0.2.1
 description = Install and manage Python packages at runtime using the "smuggle" statement.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
some of the logic in `davos.core.project._get_project_name_type` was flawed for Colab notebooks that have the `.ipynb` extension in their shown name (unlike the default). This fixes that in a general way that should work for all colab notebooks.