### PR TITLE
account for just-installed packages using pkg_resources internally

### DIFF
--- a/davos/core/core.py
+++ b/davos/core/core.py
@@ -1077,6 +1077,13 @@ def smuggle(
         # invalidate sys.meta_path module finder caches. Forces import
         # machinery to notice newly installed module
         importlib.invalidate_caches()
+        # if pkg_resources module has already been loaded, reload it in
+        # case the just-installed package uses it internally to populate
+        # its __version__ attribute from its metadata, Otherwise,
+        # pkg_resources's cached working set won't include the new
+        # package
+        if 'pkg_resources' in sys.modules:
+            importlib.reload(sys.modules['pkg_resources'])
         # check whether the smuggled package and/or any
         # installed/updated dependencies were already imported during
         # the current runtime

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = davos
-version = 0.2.1
+version = 0.2.2
 description = Install and manage Python packages at runtime using the "smuggle" statement.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Account for the possibility that a smuggled package might use the deprecated `pkg_resources.get_distribution()` method of getting its version string from its metadata, instead of `importlib.metadata`. If so, `pkg_resources`'s cached working set won't include the new package and importing it after installing it will fail. 

Added a couple lines to davos to reload `pkg_resources` and bust its cache if it's been imported during the current interpreter's lifetime to account for this.